### PR TITLE
The logger can now "zoom in" on your favorite parameters

### DIFF
--- a/Apps/PcmHammer/PcmHammer.csproj
+++ b/Apps/PcmHammer/PcmHammer.csproj
@@ -36,7 +36,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\Jouko\AppData\Local\Temp\vsD06A.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\nate\AppData\Local\Temp\vsAB0C.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -46,7 +46,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\Jouko\AppData\Local\Temp\vsD06A.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\nate\AppData\Local\Temp\vsAB0C.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>0411_256px.ico</ApplicationIcon>

--- a/Apps/PcmHammer/PcmHammer.csproj
+++ b/Apps/PcmHammer/PcmHammer.csproj
@@ -36,7 +36,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\nate\AppData\Local\Temp\vsAB0C.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jouko\AppData\Local\Temp\vsD06A.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -46,7 +46,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\nate\AppData\Local\Temp\vsAB0C.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jouko\AppData\Local\Temp\vsD06A.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>0411_256px.ico</ApplicationIcon>

--- a/Apps/PcmLibrary/Logging/LogColumn.cs
+++ b/Apps/PcmLibrary/Logging/LogColumn.cs
@@ -20,13 +20,16 @@ namespace PcmHacking
         /// </summary>
         public Conversion Conversion { get; private set; }
 
+        public bool Zoom { get; private set; }
+
         /// <summary>
         /// Constructor.
         /// </summary>
-        public LogColumn(Parameter parameter, Conversion conversion)
+        public LogColumn(Parameter parameter, Conversion conversion, bool zoom)
         {
             this.Parameter = parameter;
             this.Conversion = conversion;
+            this.Zoom = zoom;
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/Logging/LogProfileReader.cs
+++ b/Apps/PcmLibrary/Logging/LogProfileReader.cs
@@ -59,12 +59,13 @@ namespace PcmHacking
                 {
                     string id = parameterElement.Attribute("id").Value;
                     string units = parameterElement.Attribute("units").Value;
-                    this.AddParameterToProfile<T>(id, units);
+                    bool zoom = parameterElement.Attribute("zoom").Value == "true";
+                    this.AddParameterToProfile<T>(id, units, zoom);
                 }
             }
         }
 
-        private void AddParameterToProfile<T>(string id, string units) where T : Parameter
+        private void AddParameterToProfile<T>(string id, string units, bool zoom) where T : Parameter
         {
             T parameter;
             if (!this.database.TryGetParameter<T>(id, out parameter))
@@ -86,7 +87,7 @@ namespace PcmHacking
                 throw new Exception(String.Format("Conversion {0} for parameter {1} not found when loading profile.", units, id));
             }
 
-            LogColumn column = new LogColumn(parameter, conversion);
+            LogColumn column = new LogColumn(parameter, conversion, zoom);
 
             this.profile.AddColumn(column);
         }

--- a/Apps/PcmLibrary/Logging/LogProfileReader.cs
+++ b/Apps/PcmLibrary/Logging/LogProfileReader.cs
@@ -59,7 +59,8 @@ namespace PcmHacking
                 {
                     string id = parameterElement.Attribute("id").Value;
                     string units = parameterElement.Attribute("units").Value;
-                    bool zoom = parameterElement.Attribute("zoom").Value == "true";
+                    string zoomAttributeValue = parameterElement.Attribute("zoom")?.Value;
+                    bool zoom = string.Equals(zoomAttributeValue, "true", StringComparison.OrdinalIgnoreCase);
                     this.AddParameterToProfile<T>(id, units, zoom);
                 }
             }

--- a/Apps/PcmLibrary/Logging/LogProfileWriter.cs
+++ b/Apps/PcmLibrary/Logging/LogProfileWriter.cs
@@ -50,6 +50,7 @@ namespace PcmHacking
                     XElement element = new XElement(parameterType);
                     element.SetAttributeValue("id", column.Parameter.Id);
                     element.SetAttributeValue("units", column.Conversion.Units);
+                    element.SetAttributeValue("zoom", column.Zoom.ToString());
                     parameterListElement.Add(element);
                 }
             }

--- a/Apps/PcmLibrary/Logging/Logger.cs
+++ b/Apps/PcmLibrary/Logging/Logger.cs
@@ -131,14 +131,14 @@ namespace PcmHacking
 
                 if (xColumn == null)
                 {
-                    xColumn = new LogColumn(mathParameter.XColumn.Parameter, mathParameter.XColumn.Conversion);
+                    xColumn = new LogColumn(mathParameter.XColumn.Parameter, mathParameter.XColumn.Conversion, false);
                     pcmColumns.Add(xColumn);
                 }
 
                 LogColumn yColumn = pcmColumns.Where(y => y.Parameter == mathParameter.YColumn.Parameter).FirstOrDefault();
                 if (yColumn == null)
                 {
-                    yColumn = new LogColumn(mathParameter.YColumn.Parameter, mathParameter.YColumn.Conversion);
+                    yColumn = new LogColumn(mathParameter.YColumn.Parameter, mathParameter.YColumn.Conversion, false);
                     pcmColumns.Add(yColumn);
                 }
 

--- a/Apps/PcmLibrary/Logging/MathValueProcessor.cs
+++ b/Apps/PcmLibrary/Logging/MathValueProcessor.cs
@@ -76,6 +76,10 @@ namespace PcmHacking
                     finalConverter.SetVariable("x", xParameterValue);
                     finalConverter.SetVariable("y", yParameterValue);
                     double converted = finalConverter.Eval<double>(value.MathColumn.Conversion.Expression);
+                    if (double.IsNaN(converted))
+                    {
+                        converted = 0;
+                    }
                     result.Add(converted.ToString(value.MathColumn.Conversion.Format));
                 }
                 catch (Exception exception)

--- a/Apps/PcmLibrary/Logging/ParameterDatabase.cs
+++ b/Apps/PcmLibrary/Logging/ParameterDatabase.cs
@@ -272,7 +272,7 @@ namespace PcmHacking
                 throw new Exception(String.Format("No conversion found for {0} in {1}", units, parameterName));
             }
 
-            return new LogColumn(xParameter, xConversion);
+            return new LogColumn(xParameter, xConversion, false);
         }
 
         List<Conversion> GetConversions(XElement parameterElement)

--- a/Apps/PcmLogger/MainForm.Can.cs
+++ b/Apps/PcmLogger/MainForm.Can.cs
@@ -95,7 +95,7 @@ namespace PcmHacking
             {
                 DataGridViewRow row = new DataGridViewRow();
                 row.CreateCells(this.canParameterGrid);
-                row.Cells[0].Value = parameter;
+                row.Cells[CellIndexEnable].Value = parameter;
 
                 DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)row.Cells[1];
                 cell.DisplayMember = "Units";
@@ -162,7 +162,7 @@ namespace PcmHacking
 
             DataGridViewRow row = this.canParameterGrid.Rows[e.RowIndex];
 
-            CanParameter parameter = row.Cells[0].Value as CanParameter;
+            CanParameter parameter = row.Cells[CellIndexEnable].Value as CanParameter;
 
             DataGridViewComboBoxCell cell = row.Cells[e.ColumnIndex] as DataGridViewComboBoxCell;
             string conversionName = cell.Value as string;

--- a/Apps/PcmLogger/MainForm.Designer.cs
+++ b/Apps/PcmLogger/MainForm.Designer.cs
@@ -89,11 +89,10 @@
             this.loggerProgress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.loggerProgress.Enabled = false;
-            this.loggerProgress.Location = new System.Drawing.Point(325, 14);
-            this.loggerProgress.Margin = new System.Windows.Forms.Padding(4);
+            this.loggerProgress.Location = new System.Drawing.Point(244, 11);
             this.loggerProgress.MarqueeAnimationSpeed = 0;
             this.loggerProgress.Name = "loggerProgress";
-            this.loggerProgress.Size = new System.Drawing.Size(941, 58);
+            this.loggerProgress.Size = new System.Drawing.Size(706, 47);
             this.loggerProgress.Step = 0;
             this.loggerProgress.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.loggerProgress.TabIndex = 5;
@@ -112,10 +111,9 @@
             // startStopSaving
             // 
             this.startStopSaving.Enabled = false;
-            this.startStopSaving.Location = new System.Drawing.Point(16, 14);
-            this.startStopSaving.Margin = new System.Windows.Forms.Padding(4);
+            this.startStopSaving.Location = new System.Drawing.Point(12, 11);
             this.startStopSaving.Name = "startStopSaving";
-            this.startStopSaving.Size = new System.Drawing.Size(287, 58);
+            this.startStopSaving.Size = new System.Drawing.Size(215, 47);
             this.startStopSaving.TabIndex = 4;
             this.startStopSaving.Text = "Start &Recording";
             this.startStopSaving.UseVisualStyleBackColor = true;
@@ -126,7 +124,8 @@
             this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitContainer1.Location = new System.Drawing.Point(0, 80);
+            this.splitContainer1.Location = new System.Drawing.Point(0, 65);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -136,8 +135,9 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
-            this.splitContainer1.Size = new System.Drawing.Size(1280, 674);
-            this.splitContainer1.SplitterDistance = 623;
+            this.splitContainer1.Size = new System.Drawing.Size(960, 548);
+            this.splitContainer1.SplitterDistance = 400;
+            this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 9;
             // 
             // tabs
@@ -149,10 +149,9 @@
             this.tabs.Controls.Add(this.debugTab);
             this.tabs.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabs.Location = new System.Drawing.Point(0, 0);
-            this.tabs.Margin = new System.Windows.Forms.Padding(4);
             this.tabs.Name = "tabs";
             this.tabs.SelectedIndex = 0;
-            this.tabs.Size = new System.Drawing.Size(623, 674);
+            this.tabs.Size = new System.Drawing.Size(400, 548);
             this.tabs.TabIndex = 8;
             // 
             // configurationTab
@@ -163,10 +162,10 @@
             this.configurationTab.Controls.Add(this.selectButton);
             this.configurationTab.Controls.Add(this.setDirectory);
             this.configurationTab.Controls.Add(this.deviceDescription);
-            this.configurationTab.Location = new System.Drawing.Point(4, 25);
-            this.configurationTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.configurationTab.Location = new System.Drawing.Point(4, 22);
+            this.configurationTab.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.configurationTab.Name = "configurationTab";
-            this.configurationTab.Size = new System.Drawing.Size(615, 645);
+            this.configurationTab.Size = new System.Drawing.Size(392, 522);
             this.configurationTab.TabIndex = 3;
             this.configurationTab.Text = "Configuration";
             this.configurationTab.UseVisualStyleBackColor = true;
@@ -175,10 +174,9 @@
             // 
             this.disclaimer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.disclaimer.Location = new System.Drawing.Point(5, 178);
-            this.disclaimer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.disclaimer.Location = new System.Drawing.Point(4, 145);
             this.disclaimer.Name = "disclaimer";
-            this.disclaimer.Size = new System.Drawing.Size(531, 172);
+            this.disclaimer.Size = new System.Drawing.Size(331, 140);
             this.disclaimer.TabIndex = 10;
             this.disclaimer.Text = resources.GetString("disclaimer.Text");
             // 
@@ -186,19 +184,17 @@
             // 
             this.logFilePath.AutoSize = true;
             this.logFilePath.BackColor = System.Drawing.Color.Transparent;
-            this.logFilePath.Location = new System.Drawing.Point(153, 85);
-            this.logFilePath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.logFilePath.Location = new System.Drawing.Point(115, 69);
             this.logFilePath.Name = "logFilePath";
-            this.logFilePath.Size = new System.Drawing.Size(65, 17);
+            this.logFilePath.Size = new System.Drawing.Size(49, 13);
             this.logFilePath.TabIndex = 7;
             this.logFilePath.Text = "Directory";
             // 
             // openDirectory
             // 
-            this.openDirectory.Location = new System.Drawing.Point(5, 114);
-            this.openDirectory.Margin = new System.Windows.Forms.Padding(4);
+            this.openDirectory.Location = new System.Drawing.Point(4, 93);
             this.openDirectory.Name = "openDirectory";
-            this.openDirectory.Size = new System.Drawing.Size(139, 28);
+            this.openDirectory.Size = new System.Drawing.Size(104, 23);
             this.openDirectory.TabIndex = 9;
             this.openDirectory.Text = "&Open Log Folder";
             this.openDirectory.UseVisualStyleBackColor = true;
@@ -206,10 +202,9 @@
             // 
             // selectButton
             // 
-            this.selectButton.Location = new System.Drawing.Point(4, 4);
-            this.selectButton.Margin = new System.Windows.Forms.Padding(4);
+            this.selectButton.Location = new System.Drawing.Point(3, 3);
             this.selectButton.Name = "selectButton";
-            this.selectButton.Size = new System.Drawing.Size(288, 31);
+            this.selectButton.Size = new System.Drawing.Size(216, 25);
             this.selectButton.TabIndex = 0;
             this.selectButton.Text = "&Select OBD2 Device";
             this.selectButton.UseVisualStyleBackColor = true;
@@ -217,10 +212,9 @@
             // 
             // setDirectory
             // 
-            this.setDirectory.Location = new System.Drawing.Point(5, 79);
-            this.setDirectory.Margin = new System.Windows.Forms.Padding(4);
+            this.setDirectory.Location = new System.Drawing.Point(4, 64);
             this.setDirectory.Name = "setDirectory";
-            this.setDirectory.Size = new System.Drawing.Size(140, 28);
+            this.setDirectory.Size = new System.Drawing.Size(105, 23);
             this.setDirectory.TabIndex = 6;
             this.setDirectory.Text = "Set Log &Folder";
             this.setDirectory.UseVisualStyleBackColor = true;
@@ -229,10 +223,9 @@
             // deviceDescription
             // 
             this.deviceDescription.AutoSize = true;
-            this.deviceDescription.Location = new System.Drawing.Point(300, 11);
-            this.deviceDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.deviceDescription.Location = new System.Drawing.Point(225, 9);
             this.deviceDescription.Name = "deviceDescription";
-            this.deviceDescription.Size = new System.Drawing.Size(114, 17);
+            this.deviceDescription.Size = new System.Drawing.Size(88, 13);
             this.deviceDescription.TabIndex = 1;
             this.deviceDescription.Text = "[selected device]";
             // 
@@ -244,10 +237,10 @@
             this.profilesTab.Controls.Add(this.profileList);
             this.profilesTab.Controls.Add(this.saveAsButton);
             this.profilesTab.Controls.Add(this.saveButton);
-            this.profilesTab.Location = new System.Drawing.Point(4, 25);
-            this.profilesTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.profilesTab.Location = new System.Drawing.Point(4, 22);
+            this.profilesTab.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.profilesTab.Name = "profilesTab";
-            this.profilesTab.Size = new System.Drawing.Size(615, 645);
+            this.profilesTab.Size = new System.Drawing.Size(459, 522);
             this.profilesTab.TabIndex = 4;
             this.profilesTab.Text = "Profiles";
             this.profilesTab.UseVisualStyleBackColor = true;
@@ -255,10 +248,10 @@
             // removeProfileButton
             // 
             this.removeProfileButton.Enabled = false;
-            this.removeProfileButton.Location = new System.Drawing.Point(888, 4);
-            this.removeProfileButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.removeProfileButton.Location = new System.Drawing.Point(666, 3);
+            this.removeProfileButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.removeProfileButton.Name = "removeProfileButton";
-            this.removeProfileButton.Size = new System.Drawing.Size(100, 31);
+            this.removeProfileButton.Size = new System.Drawing.Size(75, 25);
             this.removeProfileButton.TabIndex = 5;
             this.removeProfileButton.Text = "&Remove";
             this.removeProfileButton.UseVisualStyleBackColor = true;
@@ -266,10 +259,10 @@
             // 
             // openButton
             // 
-            this.openButton.Location = new System.Drawing.Point(109, 2);
-            this.openButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.openButton.Location = new System.Drawing.Point(82, 2);
+            this.openButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.openButton.Name = "openButton";
-            this.openButton.Size = new System.Drawing.Size(100, 31);
+            this.openButton.Size = new System.Drawing.Size(75, 25);
             this.openButton.TabIndex = 4;
             this.openButton.Text = "&Open";
             this.openButton.UseVisualStyleBackColor = true;
@@ -277,10 +270,10 @@
             // 
             // newButton
             // 
-            this.newButton.Location = new System.Drawing.Point(3, 2);
-            this.newButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.newButton.Location = new System.Drawing.Point(2, 2);
+            this.newButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.newButton.Name = "newButton";
-            this.newButton.Size = new System.Drawing.Size(100, 31);
+            this.newButton.Size = new System.Drawing.Size(75, 25);
             this.newButton.TabIndex = 3;
             this.newButton.Text = "&New";
             this.newButton.UseVisualStyleBackColor = true;
@@ -293,20 +286,19 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.profileList.FormattingEnabled = true;
             this.profileList.IntegralHeight = false;
-            this.profileList.ItemHeight = 16;
-            this.profileList.Location = new System.Drawing.Point(3, 39);
-            this.profileList.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.profileList.Location = new System.Drawing.Point(2, 32);
+            this.profileList.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.profileList.Name = "profileList";
-            this.profileList.Size = new System.Drawing.Size(688, 600);
+            this.profileList.Size = new System.Drawing.Size(517, 491);
             this.profileList.TabIndex = 2;
             this.profileList.SelectedIndexChanged += new System.EventHandler(this.profileList_SelectedIndexChanged);
             // 
             // saveAsButton
             // 
-            this.saveAsButton.Location = new System.Drawing.Point(321, 2);
-            this.saveAsButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.saveAsButton.Location = new System.Drawing.Point(241, 2);
+            this.saveAsButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.saveAsButton.Name = "saveAsButton";
-            this.saveAsButton.Size = new System.Drawing.Size(100, 31);
+            this.saveAsButton.Size = new System.Drawing.Size(75, 25);
             this.saveAsButton.TabIndex = 1;
             this.saveAsButton.Text = "Save &As";
             this.saveAsButton.UseVisualStyleBackColor = true;
@@ -314,10 +306,10 @@
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(215, 2);
-            this.saveButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.saveButton.Location = new System.Drawing.Point(161, 2);
+            this.saveButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(100, 31);
+            this.saveButton.Size = new System.Drawing.Size(75, 25);
             this.saveButton.TabIndex = 0;
             this.saveButton.Text = "&Save";
             this.saveButton.UseVisualStyleBackColor = true;
@@ -327,10 +319,10 @@
             // 
             this.parametersTab.Controls.Add(this.parameterSearch);
             this.parametersTab.Controls.Add(this.parameterGrid);
-            this.parametersTab.Location = new System.Drawing.Point(4, 25);
-            this.parametersTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.parametersTab.Location = new System.Drawing.Point(4, 22);
+            this.parametersTab.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.parametersTab.Name = "parametersTab";
-            this.parametersTab.Size = new System.Drawing.Size(615, 645);
+            this.parametersTab.Size = new System.Drawing.Size(459, 522);
             this.parametersTab.TabIndex = 2;
             this.parametersTab.Text = "Parameters";
             this.parametersTab.UseVisualStyleBackColor = true;
@@ -339,10 +331,9 @@
             // 
             this.parameterSearch.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.parameterSearch.Location = new System.Drawing.Point(4, 4);
-            this.parameterSearch.Margin = new System.Windows.Forms.Padding(4);
+            this.parameterSearch.Location = new System.Drawing.Point(3, 3);
             this.parameterSearch.Name = "parameterSearch";
-            this.parameterSearch.Size = new System.Drawing.Size(607, 22);
+            this.parameterSearch.Size = new System.Drawing.Size(456, 20);
             this.parameterSearch.TabIndex = 1;
             this.parameterSearch.TextChanged += new System.EventHandler(this.parameterSearch_TextChanged);
             this.parameterSearch.Enter += new System.EventHandler(this.parameterSearch_Enter);
@@ -364,8 +355,8 @@
             this.Zoom,
             this.nameColumn,
             this.unitsColumn});
-            this.parameterGrid.Location = new System.Drawing.Point(0, 34);
-            this.parameterGrid.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.parameterGrid.Location = new System.Drawing.Point(0, 28);
+            this.parameterGrid.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.parameterGrid.Name = "parameterGrid";
             this.parameterGrid.RowHeadersVisible = false;
             this.parameterGrid.RowHeadersWidth = 51;
@@ -374,7 +365,7 @@
             this.parameterGrid.ShowCellErrors = false;
             this.parameterGrid.ShowEditingIcon = false;
             this.parameterGrid.ShowRowErrors = false;
-            this.parameterGrid.Size = new System.Drawing.Size(611, 611);
+            this.parameterGrid.Size = new System.Drawing.Size(458, 499);
             this.parameterGrid.TabIndex = 0;
             this.parameterGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.parameterGrid_CellContentClick);
             this.parameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.parameterGrid_CellValueChanged);
@@ -388,7 +379,7 @@
             this.enabledColumn.MinimumWidth = 35;
             this.enabledColumn.Name = "enabledColumn";
             this.enabledColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.enabledColumn.Width = 81;
+            this.enabledColumn.Width = 65;
             // 
             // Zoom
             // 
@@ -399,7 +390,7 @@
             this.Zoom.Name = "Zoom";
             this.Zoom.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.Zoom.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Zoom.Width = 73;
+            this.Zoom.Width = 59;
             // 
             // nameColumn
             // 
@@ -426,9 +417,10 @@
             this.canTab.Controls.Add(this.enableCanLogging);
             this.canTab.Controls.Add(this.canDeviceDescription);
             this.canTab.Controls.Add(this.selectCanButton);
-            this.canTab.Location = new System.Drawing.Point(4, 25);
+            this.canTab.Location = new System.Drawing.Point(4, 22);
+            this.canTab.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.canTab.Name = "canTab";
-            this.canTab.Size = new System.Drawing.Size(615, 645);
+            this.canTab.Size = new System.Drawing.Size(459, 522);
             this.canTab.TabIndex = 5;
             this.canTab.Text = "CAN Bus";
             this.canTab.UseVisualStyleBackColor = true;
@@ -446,13 +438,14 @@
             this.canParameterNameColumn,
             this.canParameterUnitsColumn});
             this.canParameterGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
-            this.canParameterGrid.Location = new System.Drawing.Point(3, 63);
+            this.canParameterGrid.Location = new System.Drawing.Point(2, 51);
+            this.canParameterGrid.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.canParameterGrid.MultiSelect = false;
             this.canParameterGrid.Name = "canParameterGrid";
             this.canParameterGrid.RowHeadersVisible = false;
             this.canParameterGrid.RowHeadersWidth = 51;
             this.canParameterGrid.RowTemplate.Height = 24;
-            this.canParameterGrid.Size = new System.Drawing.Size(691, 579);
+            this.canParameterGrid.Size = new System.Drawing.Size(518, 473);
             this.canParameterGrid.TabIndex = 17;
             this.canParameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.canParameterGrid_CellValueChanged);
             this.canParameterGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.canParameterGrid_CurrentCellDirtyStateChanged);
@@ -479,9 +472,10 @@
             // 
             this.disableCanLogging.AutoSize = true;
             this.disableCanLogging.Checked = true;
-            this.disableCanLogging.Location = new System.Drawing.Point(4, 30);
+            this.disableCanLogging.Location = new System.Drawing.Point(3, 24);
+            this.disableCanLogging.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.disableCanLogging.Name = "disableCanLogging";
-            this.disableCanLogging.Size = new System.Drawing.Size(163, 21);
+            this.disableCanLogging.Size = new System.Drawing.Size(126, 17);
             this.disableCanLogging.TabIndex = 16;
             this.disableCanLogging.TabStop = true;
             this.disableCanLogging.Text = "&Disable CAN Logging";
@@ -491,9 +485,10 @@
             // enableCanLogging
             // 
             this.enableCanLogging.AutoSize = true;
-            this.enableCanLogging.Location = new System.Drawing.Point(4, 4);
+            this.enableCanLogging.Location = new System.Drawing.Point(3, 3);
+            this.enableCanLogging.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.enableCanLogging.Name = "enableCanLogging";
-            this.enableCanLogging.Size = new System.Drawing.Size(160, 21);
+            this.enableCanLogging.Size = new System.Drawing.Size(124, 17);
             this.enableCanLogging.TabIndex = 15;
             this.enableCanLogging.Text = "&Enable CAN Logging";
             this.enableCanLogging.UseVisualStyleBackColor = true;
@@ -503,20 +498,18 @@
             // 
             this.canDeviceDescription.AutoSize = true;
             this.canDeviceDescription.Enabled = false;
-            this.canDeviceDescription.Location = new System.Drawing.Point(373, 32);
-            this.canDeviceDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.canDeviceDescription.Location = new System.Drawing.Point(280, 26);
             this.canDeviceDescription.Name = "canDeviceDescription";
-            this.canDeviceDescription.Size = new System.Drawing.Size(114, 17);
+            this.canDeviceDescription.Size = new System.Drawing.Size(88, 13);
             this.canDeviceDescription.TabIndex = 14;
             this.canDeviceDescription.Text = "[selected device]";
             // 
             // selectCanButton
             // 
             this.selectCanButton.Enabled = false;
-            this.selectCanButton.Location = new System.Drawing.Point(199, 25);
-            this.selectCanButton.Margin = new System.Windows.Forms.Padding(4);
+            this.selectCanButton.Location = new System.Drawing.Point(149, 20);
             this.selectCanButton.Name = "selectCanButton";
-            this.selectCanButton.Size = new System.Drawing.Size(166, 31);
+            this.selectCanButton.Size = new System.Drawing.Size(124, 25);
             this.selectCanButton.TabIndex = 13;
             this.selectCanButton.Text = "Select &CAN Device";
             this.selectCanButton.UseVisualStyleBackColor = true;
@@ -525,11 +518,10 @@
             // debugTab
             // 
             this.debugTab.Controls.Add(this.debugLog);
-            this.debugTab.Location = new System.Drawing.Point(4, 25);
-            this.debugTab.Margin = new System.Windows.Forms.Padding(4);
+            this.debugTab.Location = new System.Drawing.Point(4, 22);
             this.debugTab.Name = "debugTab";
-            this.debugTab.Padding = new System.Windows.Forms.Padding(4);
-            this.debugTab.Size = new System.Drawing.Size(615, 645);
+            this.debugTab.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.debugTab.Size = new System.Drawing.Size(459, 522);
             this.debugTab.TabIndex = 1;
             this.debugTab.Text = "Debug";
             this.debugTab.UseVisualStyleBackColor = true;
@@ -537,19 +529,19 @@
             // debugLog
             // 
             this.debugLog.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.debugLog.Location = new System.Drawing.Point(4, 4);
-            this.debugLog.Margin = new System.Windows.Forms.Padding(4);
+            this.debugLog.Location = new System.Drawing.Point(3, 3);
             this.debugLog.Multiline = true;
             this.debugLog.Name = "debugLog";
             this.debugLog.ReadOnly = true;
             this.debugLog.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.debugLog.Size = new System.Drawing.Size(607, 637);
+            this.debugLog.Size = new System.Drawing.Size(453, 516);
             this.debugLog.TabIndex = 0;
             // 
             // splitContainer2
             // 
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.splitContainer2.Name = "splitContainer2";
             // 
             // splitContainer2.Panel1
@@ -557,30 +549,29 @@
             this.splitContainer2.Panel1.Controls.Add(this.logValues);
             this.splitContainer2.Panel1MinSize = 200;
             this.splitContainer2.Panel2MinSize = 200;
-            this.splitContainer2.Size = new System.Drawing.Size(653, 674);
-            this.splitContainer2.SplitterDistance = 296;
+            this.splitContainer2.Size = new System.Drawing.Size(557, 548);
+            this.splitContainer2.SplitterDistance = 252;
+            this.splitContainer2.SplitterWidth = 3;
             this.splitContainer2.TabIndex = 1;
             // 
             // logValues
             // 
             this.logValues.Dock = System.Windows.Forms.DockStyle.Fill;
             this.logValues.Location = new System.Drawing.Point(0, 0);
-            this.logValues.Margin = new System.Windows.Forms.Padding(4);
             this.logValues.Multiline = true;
             this.logValues.Name = "logValues";
             this.logValues.ReadOnly = true;
-            this.logValues.Size = new System.Drawing.Size(296, 674);
+            this.logValues.Size = new System.Drawing.Size(252, 548);
             this.logValues.TabIndex = 0;
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1282, 753);
+            this.ClientSize = new System.Drawing.Size(962, 612);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.loggerProgress);
             this.Controls.Add(this.startStopSaving);
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "MainForm";
             this.Text = "(window title is set programmatically)";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);

--- a/Apps/PcmLogger/MainForm.Designer.cs
+++ b/Apps/PcmLogger/MainForm.Designer.cs
@@ -51,9 +51,6 @@
             this.parametersTab = new System.Windows.Forms.TabPage();
             this.parameterSearch = new System.Windows.Forms.TextBox();
             this.parameterGrid = new System.Windows.Forms.DataGridView();
-            this.enabledColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.nameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.unitsColumn = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.canTab = new System.Windows.Forms.TabPage();
             this.canParameterGrid = new System.Windows.Forms.DataGridView();
             this.canParameterNameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -64,7 +61,12 @@
             this.selectCanButton = new System.Windows.Forms.Button();
             this.debugTab = new System.Windows.Forms.TabPage();
             this.debugLog = new System.Windows.Forms.TextBox();
+            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.logValues = new System.Windows.Forms.TextBox();
+            this.enabledColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.Zoom = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.nameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.unitsColumn = new System.Windows.Forms.DataGridViewComboBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -77,6 +79,9 @@
             this.canTab.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.canParameterGrid)).BeginInit();
             this.debugTab.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
+            this.splitContainer2.Panel1.SuspendLayout();
+            this.splitContainer2.SuspendLayout();
             this.SuspendLayout();
             // 
             // loggerProgress
@@ -88,7 +93,7 @@
             this.loggerProgress.Margin = new System.Windows.Forms.Padding(4);
             this.loggerProgress.MarqueeAnimationSpeed = 0;
             this.loggerProgress.Name = "loggerProgress";
-            this.loggerProgress.Size = new System.Drawing.Size(692, 58);
+            this.loggerProgress.Size = new System.Drawing.Size(791, 58);
             this.loggerProgress.Step = 0;
             this.loggerProgress.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.loggerProgress.TabIndex = 5;
@@ -130,9 +135,9 @@
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.logValues);
-            this.splitContainer1.Size = new System.Drawing.Size(1031, 543);
-            this.splitContainer1.SplitterDistance = 600;
+            this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
+            this.splitContainer1.Size = new System.Drawing.Size(1130, 609);
+            this.splitContainer1.SplitterDistance = 577;
             this.splitContainer1.TabIndex = 9;
             // 
             // tabs
@@ -147,7 +152,7 @@
             this.tabs.Margin = new System.Windows.Forms.Padding(4);
             this.tabs.Name = "tabs";
             this.tabs.SelectedIndex = 0;
-            this.tabs.Size = new System.Drawing.Size(600, 543);
+            this.tabs.Size = new System.Drawing.Size(577, 609);
             this.tabs.TabIndex = 8;
             // 
             // configurationTab
@@ -161,7 +166,7 @@
             this.configurationTab.Location = new System.Drawing.Point(4, 25);
             this.configurationTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.configurationTab.Name = "configurationTab";
-            this.configurationTab.Size = new System.Drawing.Size(592, 514);
+            this.configurationTab.Size = new System.Drawing.Size(569, 580);
             this.configurationTab.TabIndex = 3;
             this.configurationTab.Text = "Configuration";
             this.configurationTab.UseVisualStyleBackColor = true;
@@ -173,7 +178,7 @@
             this.disclaimer.Location = new System.Drawing.Point(5, 178);
             this.disclaimer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.disclaimer.Name = "disclaimer";
-            this.disclaimer.Size = new System.Drawing.Size(584, 172);
+            this.disclaimer.Size = new System.Drawing.Size(485, 172);
             this.disclaimer.TabIndex = 10;
             this.disclaimer.Text = resources.GetString("disclaimer.Text");
             // 
@@ -184,7 +189,7 @@
             this.logFilePath.Location = new System.Drawing.Point(153, 85);
             this.logFilePath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.logFilePath.Name = "logFilePath";
-            this.logFilePath.Size = new System.Drawing.Size(65, 17);
+            this.logFilePath.Size = new System.Drawing.Size(61, 16);
             this.logFilePath.TabIndex = 7;
             this.logFilePath.Text = "Directory";
             // 
@@ -227,7 +232,7 @@
             this.deviceDescription.Location = new System.Drawing.Point(300, 11);
             this.deviceDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.deviceDescription.Name = "deviceDescription";
-            this.deviceDescription.Size = new System.Drawing.Size(114, 17);
+            this.deviceDescription.Size = new System.Drawing.Size(111, 16);
             this.deviceDescription.TabIndex = 1;
             this.deviceDescription.Text = "[selected device]";
             // 
@@ -242,7 +247,7 @@
             this.profilesTab.Location = new System.Drawing.Point(4, 25);
             this.profilesTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.profilesTab.Name = "profilesTab";
-            this.profilesTab.Size = new System.Drawing.Size(592, 514);
+            this.profilesTab.Size = new System.Drawing.Size(569, 580);
             this.profilesTab.TabIndex = 4;
             this.profilesTab.Text = "Profiles";
             this.profilesTab.UseVisualStyleBackColor = true;
@@ -292,7 +297,7 @@
             this.profileList.Location = new System.Drawing.Point(3, 39);
             this.profileList.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.profileList.Name = "profileList";
-            this.profileList.Size = new System.Drawing.Size(583, 469);
+            this.profileList.Size = new System.Drawing.Size(642, 535);
             this.profileList.TabIndex = 2;
             this.profileList.SelectedIndexChanged += new System.EventHandler(this.profileList_SelectedIndexChanged);
             // 
@@ -325,7 +330,7 @@
             this.parametersTab.Location = new System.Drawing.Point(4, 25);
             this.parametersTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.parametersTab.Name = "parametersTab";
-            this.parametersTab.Size = new System.Drawing.Size(592, 514);
+            this.parametersTab.Size = new System.Drawing.Size(569, 580);
             this.parametersTab.TabIndex = 2;
             this.parametersTab.Text = "Parameters";
             this.parametersTab.UseVisualStyleBackColor = true;
@@ -337,7 +342,7 @@
             this.parameterSearch.Location = new System.Drawing.Point(4, 4);
             this.parameterSearch.Margin = new System.Windows.Forms.Padding(4);
             this.parameterSearch.Name = "parameterSearch";
-            this.parameterSearch.Size = new System.Drawing.Size(584, 22);
+            this.parameterSearch.Size = new System.Drawing.Size(561, 22);
             this.parameterSearch.TabIndex = 1;
             this.parameterSearch.TextChanged += new System.EventHandler(this.parameterSearch_TextChanged);
             this.parameterSearch.Enter += new System.EventHandler(this.parameterSearch_Enter);
@@ -356,6 +361,7 @@
             this.parameterGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.parameterGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.enabledColumn,
+            this.Zoom,
             this.nameColumn,
             this.unitsColumn});
             this.parameterGrid.Location = new System.Drawing.Point(0, 34);
@@ -368,37 +374,11 @@
             this.parameterGrid.ShowCellErrors = false;
             this.parameterGrid.ShowEditingIcon = false;
             this.parameterGrid.ShowRowErrors = false;
-            this.parameterGrid.Size = new System.Drawing.Size(589, 478);
+            this.parameterGrid.Size = new System.Drawing.Size(565, 546);
             this.parameterGrid.TabIndex = 0;
             this.parameterGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.parameterGrid_CellContentClick);
             this.parameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.parameterGrid_CellValueChanged);
             this.parameterGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.parameterGrid_CurrentCellDirtyStateChanged);
-            // 
-            // enabledColumn
-            // 
-            this.enabledColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.enabledColumn.FillWeight = 1F;
-            this.enabledColumn.HeaderText = "Enabled";
-            this.enabledColumn.MinimumWidth = 50;
-            this.enabledColumn.Name = "enabledColumn";
-            this.enabledColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.enabledColumn.Width = 89;
-            // 
-            // nameColumn
-            // 
-            this.nameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.nameColumn.HeaderText = "Name";
-            this.nameColumn.MinimumWidth = 100;
-            this.nameColumn.Name = "nameColumn";
-            this.nameColumn.ReadOnly = true;
-            // 
-            // unitsColumn
-            // 
-            this.unitsColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.unitsColumn.FillWeight = 1F;
-            this.unitsColumn.HeaderText = "Units";
-            this.unitsColumn.MinimumWidth = 100;
-            this.unitsColumn.Name = "unitsColumn";
             // 
             // canTab
             // 
@@ -409,7 +389,7 @@
             this.canTab.Controls.Add(this.selectCanButton);
             this.canTab.Location = new System.Drawing.Point(4, 25);
             this.canTab.Name = "canTab";
-            this.canTab.Size = new System.Drawing.Size(592, 514);
+            this.canTab.Size = new System.Drawing.Size(569, 580);
             this.canTab.TabIndex = 5;
             this.canTab.Text = "CAN Bus";
             this.canTab.UseVisualStyleBackColor = true;
@@ -433,7 +413,7 @@
             this.canParameterGrid.RowHeadersVisible = false;
             this.canParameterGrid.RowHeadersWidth = 51;
             this.canParameterGrid.RowTemplate.Height = 24;
-            this.canParameterGrid.Size = new System.Drawing.Size(586, 448);
+            this.canParameterGrid.Size = new System.Drawing.Size(645, 514);
             this.canParameterGrid.TabIndex = 17;
             this.canParameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.canParameterGrid_CellValueChanged);
             this.canParameterGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.canParameterGrid_CurrentCellDirtyStateChanged);
@@ -462,7 +442,7 @@
             this.disableCanLogging.Checked = true;
             this.disableCanLogging.Location = new System.Drawing.Point(4, 30);
             this.disableCanLogging.Name = "disableCanLogging";
-            this.disableCanLogging.Size = new System.Drawing.Size(163, 21);
+            this.disableCanLogging.Size = new System.Drawing.Size(158, 20);
             this.disableCanLogging.TabIndex = 16;
             this.disableCanLogging.TabStop = true;
             this.disableCanLogging.Text = "&Disable CAN Logging";
@@ -474,7 +454,7 @@
             this.enableCanLogging.AutoSize = true;
             this.enableCanLogging.Location = new System.Drawing.Point(4, 4);
             this.enableCanLogging.Name = "enableCanLogging";
-            this.enableCanLogging.Size = new System.Drawing.Size(160, 21);
+            this.enableCanLogging.Size = new System.Drawing.Size(154, 20);
             this.enableCanLogging.TabIndex = 15;
             this.enableCanLogging.Text = "&Enable CAN Logging";
             this.enableCanLogging.UseVisualStyleBackColor = true;
@@ -487,7 +467,7 @@
             this.canDeviceDescription.Location = new System.Drawing.Point(373, 32);
             this.canDeviceDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.canDeviceDescription.Name = "canDeviceDescription";
-            this.canDeviceDescription.Size = new System.Drawing.Size(114, 17);
+            this.canDeviceDescription.Size = new System.Drawing.Size(111, 16);
             this.canDeviceDescription.TabIndex = 14;
             this.canDeviceDescription.Text = "[selected device]";
             // 
@@ -510,7 +490,7 @@
             this.debugTab.Margin = new System.Windows.Forms.Padding(4);
             this.debugTab.Name = "debugTab";
             this.debugTab.Padding = new System.Windows.Forms.Padding(4);
-            this.debugTab.Size = new System.Drawing.Size(592, 514);
+            this.debugTab.Size = new System.Drawing.Size(569, 580);
             this.debugTab.TabIndex = 1;
             this.debugTab.Text = "Debug";
             this.debugTab.UseVisualStyleBackColor = true;
@@ -524,8 +504,23 @@
             this.debugLog.Name = "debugLog";
             this.debugLog.ReadOnly = true;
             this.debugLog.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.debugLog.Size = new System.Drawing.Size(584, 506);
+            this.debugLog.Size = new System.Drawing.Size(561, 572);
             this.debugLog.TabIndex = 0;
+            // 
+            // splitContainer2
+            // 
+            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Name = "splitContainer2";
+            // 
+            // splitContainer2.Panel1
+            // 
+            this.splitContainer2.Panel1.Controls.Add(this.logValues);
+            this.splitContainer2.Panel1MinSize = 200;
+            this.splitContainer2.Panel2MinSize = 200;
+            this.splitContainer2.Size = new System.Drawing.Size(549, 609);
+            this.splitContainer2.SplitterDistance = 250;
+            this.splitContainer2.TabIndex = 1;
             // 
             // logValues
             // 
@@ -535,14 +530,50 @@
             this.logValues.Multiline = true;
             this.logValues.Name = "logValues";
             this.logValues.ReadOnly = true;
-            this.logValues.Size = new System.Drawing.Size(427, 543);
+            this.logValues.Size = new System.Drawing.Size(250, 609);
             this.logValues.TabIndex = 0;
+            // 
+            // enabledColumn
+            // 
+            this.enabledColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.enabledColumn.FillWeight = 1F;
+            this.enabledColumn.HeaderText = "Enable";
+            this.enabledColumn.MinimumWidth = 70;
+            this.enabledColumn.Name = "enabledColumn";
+            this.enabledColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.enabledColumn.Width = 79;
+            // 
+            // Zoom
+            // 
+            this.Zoom.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.Zoom.HeaderText = "Zoom";
+            this.Zoom.MinimumWidth = 70;
+            this.Zoom.Name = "Zoom";
+            this.Zoom.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.Zoom.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.Zoom.Width = 71;
+            // 
+            // nameColumn
+            // 
+            this.nameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.nameColumn.HeaderText = "Name";
+            this.nameColumn.MinimumWidth = 200;
+            this.nameColumn.Name = "nameColumn";
+            this.nameColumn.ReadOnly = true;
+            // 
+            // unitsColumn
+            // 
+            this.unitsColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.unitsColumn.FillWeight = 1F;
+            this.unitsColumn.HeaderText = "Units";
+            this.unitsColumn.MinimumWidth = 100;
+            this.unitsColumn.Name = "unitsColumn";
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1033, 622);
+            this.ClientSize = new System.Drawing.Size(1132, 688);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.loggerProgress);
             this.Controls.Add(this.startStopSaving);
@@ -553,7 +584,6 @@
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
-            this.splitContainer1.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
             this.tabs.ResumeLayout(false);
@@ -568,6 +598,10 @@
             ((System.ComponentModel.ISupportInitialize)(this.canParameterGrid)).EndInit();
             this.debugTab.ResumeLayout(false);
             this.debugTab.PerformLayout();
+            this.splitContainer2.Panel1.ResumeLayout(false);
+            this.splitContainer2.Panel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
+            this.splitContainer2.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -591,9 +625,6 @@
         private System.Windows.Forms.TabPage parametersTab;
         private System.Windows.Forms.TextBox parameterSearch;
         private System.Windows.Forms.DataGridView parameterGrid;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn enabledColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn nameColumn;
-        private System.Windows.Forms.DataGridViewComboBoxColumn unitsColumn;
         private System.Windows.Forms.TextBox logValues;
         private System.Windows.Forms.TabPage profilesTab;
         private System.Windows.Forms.Button removeProfileButton;
@@ -610,6 +641,11 @@
         private System.Windows.Forms.Button setDirectory;
         private System.Windows.Forms.Label deviceDescription;
         private System.Windows.Forms.TabControl tabs;
+        private System.Windows.Forms.SplitContainer splitContainer2;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn enabledColumn;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn Zoom;
+        private System.Windows.Forms.DataGridViewTextBoxColumn nameColumn;
+        private System.Windows.Forms.DataGridViewComboBoxColumn unitsColumn;
     }
 }
 

--- a/Apps/PcmLogger/MainForm.Designer.cs
+++ b/Apps/PcmLogger/MainForm.Designer.cs
@@ -51,6 +51,10 @@
             this.parametersTab = new System.Windows.Forms.TabPage();
             this.parameterSearch = new System.Windows.Forms.TextBox();
             this.parameterGrid = new System.Windows.Forms.DataGridView();
+            this.enabledColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.Zoom = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.nameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.unitsColumn = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.canTab = new System.Windows.Forms.TabPage();
             this.canParameterGrid = new System.Windows.Forms.DataGridView();
             this.canParameterNameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -63,10 +67,6 @@
             this.debugLog = new System.Windows.Forms.TextBox();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.logValues = new System.Windows.Forms.TextBox();
-            this.enabledColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Zoom = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.nameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.unitsColumn = new System.Windows.Forms.DataGridViewComboBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -93,7 +93,7 @@
             this.loggerProgress.Margin = new System.Windows.Forms.Padding(4);
             this.loggerProgress.MarqueeAnimationSpeed = 0;
             this.loggerProgress.Name = "loggerProgress";
-            this.loggerProgress.Size = new System.Drawing.Size(791, 58);
+            this.loggerProgress.Size = new System.Drawing.Size(941, 58);
             this.loggerProgress.Step = 0;
             this.loggerProgress.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.loggerProgress.TabIndex = 5;
@@ -136,8 +136,8 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
-            this.splitContainer1.Size = new System.Drawing.Size(1130, 609);
-            this.splitContainer1.SplitterDistance = 577;
+            this.splitContainer1.Size = new System.Drawing.Size(1280, 674);
+            this.splitContainer1.SplitterDistance = 623;
             this.splitContainer1.TabIndex = 9;
             // 
             // tabs
@@ -152,7 +152,7 @@
             this.tabs.Margin = new System.Windows.Forms.Padding(4);
             this.tabs.Name = "tabs";
             this.tabs.SelectedIndex = 0;
-            this.tabs.Size = new System.Drawing.Size(577, 609);
+            this.tabs.Size = new System.Drawing.Size(623, 674);
             this.tabs.TabIndex = 8;
             // 
             // configurationTab
@@ -166,7 +166,7 @@
             this.configurationTab.Location = new System.Drawing.Point(4, 25);
             this.configurationTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.configurationTab.Name = "configurationTab";
-            this.configurationTab.Size = new System.Drawing.Size(569, 580);
+            this.configurationTab.Size = new System.Drawing.Size(615, 645);
             this.configurationTab.TabIndex = 3;
             this.configurationTab.Text = "Configuration";
             this.configurationTab.UseVisualStyleBackColor = true;
@@ -178,7 +178,7 @@
             this.disclaimer.Location = new System.Drawing.Point(5, 178);
             this.disclaimer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.disclaimer.Name = "disclaimer";
-            this.disclaimer.Size = new System.Drawing.Size(485, 172);
+            this.disclaimer.Size = new System.Drawing.Size(531, 172);
             this.disclaimer.TabIndex = 10;
             this.disclaimer.Text = resources.GetString("disclaimer.Text");
             // 
@@ -189,7 +189,7 @@
             this.logFilePath.Location = new System.Drawing.Point(153, 85);
             this.logFilePath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.logFilePath.Name = "logFilePath";
-            this.logFilePath.Size = new System.Drawing.Size(61, 16);
+            this.logFilePath.Size = new System.Drawing.Size(65, 17);
             this.logFilePath.TabIndex = 7;
             this.logFilePath.Text = "Directory";
             // 
@@ -232,7 +232,7 @@
             this.deviceDescription.Location = new System.Drawing.Point(300, 11);
             this.deviceDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.deviceDescription.Name = "deviceDescription";
-            this.deviceDescription.Size = new System.Drawing.Size(111, 16);
+            this.deviceDescription.Size = new System.Drawing.Size(114, 17);
             this.deviceDescription.TabIndex = 1;
             this.deviceDescription.Text = "[selected device]";
             // 
@@ -247,7 +247,7 @@
             this.profilesTab.Location = new System.Drawing.Point(4, 25);
             this.profilesTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.profilesTab.Name = "profilesTab";
-            this.profilesTab.Size = new System.Drawing.Size(569, 580);
+            this.profilesTab.Size = new System.Drawing.Size(615, 645);
             this.profilesTab.TabIndex = 4;
             this.profilesTab.Text = "Profiles";
             this.profilesTab.UseVisualStyleBackColor = true;
@@ -297,7 +297,7 @@
             this.profileList.Location = new System.Drawing.Point(3, 39);
             this.profileList.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.profileList.Name = "profileList";
-            this.profileList.Size = new System.Drawing.Size(642, 535);
+            this.profileList.Size = new System.Drawing.Size(688, 600);
             this.profileList.TabIndex = 2;
             this.profileList.SelectedIndexChanged += new System.EventHandler(this.profileList_SelectedIndexChanged);
             // 
@@ -330,7 +330,7 @@
             this.parametersTab.Location = new System.Drawing.Point(4, 25);
             this.parametersTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.parametersTab.Name = "parametersTab";
-            this.parametersTab.Size = new System.Drawing.Size(569, 580);
+            this.parametersTab.Size = new System.Drawing.Size(615, 645);
             this.parametersTab.TabIndex = 2;
             this.parametersTab.Text = "Parameters";
             this.parametersTab.UseVisualStyleBackColor = true;
@@ -342,7 +342,7 @@
             this.parameterSearch.Location = new System.Drawing.Point(4, 4);
             this.parameterSearch.Margin = new System.Windows.Forms.Padding(4);
             this.parameterSearch.Name = "parameterSearch";
-            this.parameterSearch.Size = new System.Drawing.Size(561, 22);
+            this.parameterSearch.Size = new System.Drawing.Size(607, 22);
             this.parameterSearch.TabIndex = 1;
             this.parameterSearch.TextChanged += new System.EventHandler(this.parameterSearch_TextChanged);
             this.parameterSearch.Enter += new System.EventHandler(this.parameterSearch_Enter);
@@ -374,11 +374,50 @@
             this.parameterGrid.ShowCellErrors = false;
             this.parameterGrid.ShowEditingIcon = false;
             this.parameterGrid.ShowRowErrors = false;
-            this.parameterGrid.Size = new System.Drawing.Size(565, 546);
+            this.parameterGrid.Size = new System.Drawing.Size(611, 611);
             this.parameterGrid.TabIndex = 0;
             this.parameterGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.parameterGrid_CellContentClick);
             this.parameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.parameterGrid_CellValueChanged);
             this.parameterGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.parameterGrid_CurrentCellDirtyStateChanged);
+            // 
+            // enabledColumn
+            // 
+            this.enabledColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.enabledColumn.FillWeight = 10F;
+            this.enabledColumn.HeaderText = "Enable";
+            this.enabledColumn.MinimumWidth = 35;
+            this.enabledColumn.Name = "enabledColumn";
+            this.enabledColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.enabledColumn.Width = 81;
+            // 
+            // Zoom
+            // 
+            this.Zoom.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.Zoom.FillWeight = 10F;
+            this.Zoom.HeaderText = "Zoom";
+            this.Zoom.MinimumWidth = 35;
+            this.Zoom.Name = "Zoom";
+            this.Zoom.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.Zoom.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.Zoom.Width = 73;
+            // 
+            // nameColumn
+            // 
+            this.nameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.nameColumn.FillWeight = 50F;
+            this.nameColumn.HeaderText = "Name";
+            this.nameColumn.MinimumWidth = 100;
+            this.nameColumn.Name = "nameColumn";
+            this.nameColumn.ReadOnly = true;
+            // 
+            // unitsColumn
+            // 
+            this.unitsColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.unitsColumn.FillWeight = 20F;
+            this.unitsColumn.HeaderText = "Units";
+            this.unitsColumn.MinimumWidth = 80;
+            this.unitsColumn.Name = "unitsColumn";
+            this.unitsColumn.Width = 80;
             // 
             // canTab
             // 
@@ -389,7 +428,7 @@
             this.canTab.Controls.Add(this.selectCanButton);
             this.canTab.Location = new System.Drawing.Point(4, 25);
             this.canTab.Name = "canTab";
-            this.canTab.Size = new System.Drawing.Size(569, 580);
+            this.canTab.Size = new System.Drawing.Size(615, 645);
             this.canTab.TabIndex = 5;
             this.canTab.Text = "CAN Bus";
             this.canTab.UseVisualStyleBackColor = true;
@@ -413,7 +452,7 @@
             this.canParameterGrid.RowHeadersVisible = false;
             this.canParameterGrid.RowHeadersWidth = 51;
             this.canParameterGrid.RowTemplate.Height = 24;
-            this.canParameterGrid.Size = new System.Drawing.Size(645, 514);
+            this.canParameterGrid.Size = new System.Drawing.Size(691, 579);
             this.canParameterGrid.TabIndex = 17;
             this.canParameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.canParameterGrid_CellValueChanged);
             this.canParameterGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.canParameterGrid_CurrentCellDirtyStateChanged);
@@ -442,7 +481,7 @@
             this.disableCanLogging.Checked = true;
             this.disableCanLogging.Location = new System.Drawing.Point(4, 30);
             this.disableCanLogging.Name = "disableCanLogging";
-            this.disableCanLogging.Size = new System.Drawing.Size(158, 20);
+            this.disableCanLogging.Size = new System.Drawing.Size(163, 21);
             this.disableCanLogging.TabIndex = 16;
             this.disableCanLogging.TabStop = true;
             this.disableCanLogging.Text = "&Disable CAN Logging";
@@ -454,7 +493,7 @@
             this.enableCanLogging.AutoSize = true;
             this.enableCanLogging.Location = new System.Drawing.Point(4, 4);
             this.enableCanLogging.Name = "enableCanLogging";
-            this.enableCanLogging.Size = new System.Drawing.Size(154, 20);
+            this.enableCanLogging.Size = new System.Drawing.Size(160, 21);
             this.enableCanLogging.TabIndex = 15;
             this.enableCanLogging.Text = "&Enable CAN Logging";
             this.enableCanLogging.UseVisualStyleBackColor = true;
@@ -467,7 +506,7 @@
             this.canDeviceDescription.Location = new System.Drawing.Point(373, 32);
             this.canDeviceDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.canDeviceDescription.Name = "canDeviceDescription";
-            this.canDeviceDescription.Size = new System.Drawing.Size(111, 16);
+            this.canDeviceDescription.Size = new System.Drawing.Size(114, 17);
             this.canDeviceDescription.TabIndex = 14;
             this.canDeviceDescription.Text = "[selected device]";
             // 
@@ -490,7 +529,7 @@
             this.debugTab.Margin = new System.Windows.Forms.Padding(4);
             this.debugTab.Name = "debugTab";
             this.debugTab.Padding = new System.Windows.Forms.Padding(4);
-            this.debugTab.Size = new System.Drawing.Size(569, 580);
+            this.debugTab.Size = new System.Drawing.Size(615, 645);
             this.debugTab.TabIndex = 1;
             this.debugTab.Text = "Debug";
             this.debugTab.UseVisualStyleBackColor = true;
@@ -504,7 +543,7 @@
             this.debugLog.Name = "debugLog";
             this.debugLog.ReadOnly = true;
             this.debugLog.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.debugLog.Size = new System.Drawing.Size(561, 572);
+            this.debugLog.Size = new System.Drawing.Size(607, 637);
             this.debugLog.TabIndex = 0;
             // 
             // splitContainer2
@@ -518,8 +557,8 @@
             this.splitContainer2.Panel1.Controls.Add(this.logValues);
             this.splitContainer2.Panel1MinSize = 200;
             this.splitContainer2.Panel2MinSize = 200;
-            this.splitContainer2.Size = new System.Drawing.Size(549, 609);
-            this.splitContainer2.SplitterDistance = 250;
+            this.splitContainer2.Size = new System.Drawing.Size(653, 674);
+            this.splitContainer2.SplitterDistance = 296;
             this.splitContainer2.TabIndex = 1;
             // 
             // logValues
@@ -530,50 +569,14 @@
             this.logValues.Multiline = true;
             this.logValues.Name = "logValues";
             this.logValues.ReadOnly = true;
-            this.logValues.Size = new System.Drawing.Size(250, 609);
+            this.logValues.Size = new System.Drawing.Size(296, 674);
             this.logValues.TabIndex = 0;
-            // 
-            // enabledColumn
-            // 
-            this.enabledColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.enabledColumn.FillWeight = 1F;
-            this.enabledColumn.HeaderText = "Enable";
-            this.enabledColumn.MinimumWidth = 70;
-            this.enabledColumn.Name = "enabledColumn";
-            this.enabledColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.enabledColumn.Width = 79;
-            // 
-            // Zoom
-            // 
-            this.Zoom.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Zoom.HeaderText = "Zoom";
-            this.Zoom.MinimumWidth = 70;
-            this.Zoom.Name = "Zoom";
-            this.Zoom.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.Zoom.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Zoom.Width = 71;
-            // 
-            // nameColumn
-            // 
-            this.nameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.nameColumn.HeaderText = "Name";
-            this.nameColumn.MinimumWidth = 200;
-            this.nameColumn.Name = "nameColumn";
-            this.nameColumn.ReadOnly = true;
-            // 
-            // unitsColumn
-            // 
-            this.unitsColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.unitsColumn.FillWeight = 1F;
-            this.unitsColumn.HeaderText = "Units";
-            this.unitsColumn.MinimumWidth = 100;
-            this.unitsColumn.Name = "unitsColumn";
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1132, 688);
+            this.ClientSize = new System.Drawing.Size(1282, 753);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.loggerProgress);
             this.Controls.Add(this.startStopSaving);

--- a/Apps/PcmLogger/MainForm.Designer.cs
+++ b/Apps/PcmLogger/MainForm.Designer.cs
@@ -420,7 +420,7 @@
             this.canTab.Location = new System.Drawing.Point(4, 22);
             this.canTab.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.canTab.Name = "canTab";
-            this.canTab.Size = new System.Drawing.Size(459, 522);
+            this.canTab.Size = new System.Drawing.Size(392, 522);
             this.canTab.TabIndex = 5;
             this.canTab.Text = "CAN Bus";
             this.canTab.UseVisualStyleBackColor = true;
@@ -445,7 +445,7 @@
             this.canParameterGrid.RowHeadersVisible = false;
             this.canParameterGrid.RowHeadersWidth = 51;
             this.canParameterGrid.RowTemplate.Height = 24;
-            this.canParameterGrid.Size = new System.Drawing.Size(518, 473);
+            this.canParameterGrid.Size = new System.Drawing.Size(451, 473);
             this.canParameterGrid.TabIndex = 17;
             this.canParameterGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.canParameterGrid_CellValueChanged);
             this.canParameterGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.canParameterGrid_CurrentCellDirtyStateChanged);

--- a/Apps/PcmLogger/MainForm.LoggingThread.cs
+++ b/Apps/PcmLogger/MainForm.LoggingThread.cs
@@ -54,10 +54,13 @@ namespace PcmHacking
         CanLogger canLogger;
 
         /// <summary>
-        /// Create a string that will look reasonable in the UI's main text box.
-        /// TODO: Use a grid instead.
+        /// Create a string that will look reasonable in the UI's main text box, and
+        /// build a list of parameters to show in a larger format.
+        /// 
+        /// TODO: Instead of a string for a text box, make a list of objects, and render
+        /// them as a grid.
         /// </summary>
-        private Tuple<string, List<ZoomedParameter>> FormatValuesForTextBox(Logger logger, IEnumerable<string> rowValues)
+        private Tuple<string, List<ZoomedParameter>> FormatValuesForDisplay(Logger logger, IEnumerable<string> rowValues)
         {
             List<ZoomedParameter> zoomedParameters = new List<ZoomedParameter>();
 
@@ -431,7 +434,7 @@ namespace PcmHacking
                             row.Item2.WriteLine(row.Item3);
                         }
 
-                        Tuple<string, List<ZoomedParameter>> values = FormatValuesForTextBox(
+                        Tuple<string, List<ZoomedParameter>> values = FormatValuesForDisplay(
                             row.Item1, // logger
                             row.Item3); // row values
 

--- a/Apps/PcmLogger/MainForm.LoggingThread.cs
+++ b/Apps/PcmLogger/MainForm.LoggingThread.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Runtime.CompilerServices;
 using System.Data;
+using System.Data.Common;
 
 namespace PcmHacking
 {
@@ -93,7 +94,19 @@ namespace PcmHacking
                 builder.Append(mathColumn.Conversion.Units);
                 builder.Append('\t');
                 builder.AppendLine(mathColumn.Parameter.Name);
+
+                if (mathColumn.Zoom)
+                {
+                    zoomedParameters.Add(
+                    new ZoomedParameter(
+                            mathColumn,
+                            rowValueEnumerator.Current,
+                            mathColumn.Parameter.Name,
+                            mathColumn.Conversion.Units));
+                }
             }
+
+
 
             foreach (CanLogger.ParameterValue pv in logger.CanLogger.GetParameterValues())
             {
@@ -102,8 +115,21 @@ namespace PcmHacking
                 builder.Append(pv.Units);
                 builder.Append('\t');
                 builder.AppendLine(pv.Name);
+
+
+                /* TODO: How to make this work for CAN?
+                 * 
+                 * if (column.Zoom)
+                {
+                    zoomedParameters.Add(
+                        new ZoomedParameter(
+                            column,
+                            rowValueEnumerator.Current,
+                            column.Parameter.Name,
+                            column.Conversion.Units));
+                }*/
             }
-        
+
             DateTime now = DateTime.Now;
             builder.AppendLine((now - lastLogTime).TotalMilliseconds.ToString("0.00") + "\tms\tQuery time");
             lastLogTime = now;

--- a/Apps/PcmLogger/MainForm.ParameterGrid.cs
+++ b/Apps/PcmLogger/MainForm.ParameterGrid.cs
@@ -65,6 +65,7 @@ namespace PcmHacking
                 foreach (DataGridViewRow row in this.parameterGrid.Rows)
                 {
                     row.Cells[0].Value = false;
+                    row.Cells[1].Value = false;
                 }
 
                 foreach (LogColumn column in this.currentProfile.Columns)
@@ -74,6 +75,10 @@ namespace PcmHacking
                     if (row != null)
                     {
                         row.Cells[0].Value = true;
+                        if (column.Zoom)
+                        {
+                            row.Cells[1].Value = true;
+                        }
 
                         DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)(row.Cells[2]);
                         Conversion profileConversion = column.Conversion;
@@ -126,6 +131,8 @@ namespace PcmHacking
  
             this.ResetProfile();
 
+            this.ClearZoomPanel();
+
             this.CreateProfileFromGrid();
 
             this.SetDirtyFlag(true);
@@ -155,12 +162,14 @@ namespace PcmHacking
                         }
                     }
 
-                    LogColumn column = new LogColumn(parameter, conversion);
+                    bool zoom = (bool)row.Cells[1].Value;
+                    LogColumn column = new LogColumn(parameter, conversion, zoom);
                     this.currentProfile.AddColumn(column);
                 }
             }
         }
 
+        #region Parameter search
         private bool showSearchPrompt = true;
 
         private void ShowSearchPrompt()
@@ -214,5 +223,6 @@ namespace PcmHacking
                 }
             }
         }
+        #endregion
     }
 }

--- a/Apps/PcmLogger/MainForm.ParameterGrid.cs
+++ b/Apps/PcmLogger/MainForm.ParameterGrid.cs
@@ -8,6 +8,11 @@ namespace PcmHacking
 {
     public partial class MainForm
     {
+        const int CellIndexEnable = 0;
+        const int CellIndexZoom = 1;
+        const int CellIndexParameter = 2;
+        const int CellIndexUnits = 3;
+
         //private Dictionary<string, DataGridViewRow> parameterIdsToRows;
         private ParameterDatabase database;
         private bool suspendSelectionEvents = true;
@@ -30,20 +35,21 @@ namespace PcmHacking
 
                 row.CreateCells(this.parameterGrid);
 
-                row.Cells[0].Value = false; // enabled
-                row.Cells[1].Value = parameter;
+                row.Cells[CellIndexEnable].Value = false; // enabled
+                row.Cells[CellIndexZoom].Value = false; // zoom
+                row.Cells[CellIndexParameter].Value = parameter;
 
-                DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)row.Cells[2];
+                DataGridViewComboBoxCell unitsCell = (DataGridViewComboBoxCell)row.Cells[CellIndexUnits];
 
-                cell.DisplayMember = "Units";
-                cell.ValueMember = "Units";
+                unitsCell.DisplayMember = "Units";
+                unitsCell.ValueMember = "Units";
 
                 foreach (Conversion conversion in parameter.Conversions)
                 {
-                    cell.Items.Add(conversion);
+                    unitsCell.Items.Add(conversion);
                 }
 
-                row.Cells[2].Value = parameter.Conversions.First();
+                unitsCell.Value = parameter.Conversions.First();
 
                 this.parameterGrid.Rows.Add(row);
             }
@@ -64,23 +70,24 @@ namespace PcmHacking
 
                 foreach (DataGridViewRow row in this.parameterGrid.Rows)
                 {
-                    row.Cells[0].Value = false;
-                    row.Cells[1].Value = false;
+                    row.Cells[CellIndexEnable].Value = false;
+                    row.Cells[CellIndexZoom].Value = false;
                 }
 
                 foreach (LogColumn column in this.currentProfile.Columns)
                 {
-                    DataGridViewRow row = this.parameterGrid.Rows.Cast<DataGridViewRow>().FirstOrDefault(r => r.Cells[1].Value == column.Parameter);
+                    DataGridViewRow row = this.parameterGrid.Rows.Cast<DataGridViewRow>().FirstOrDefault(
+                        r => r.Cells[CellIndexParameter].Value == column.Parameter);
 
                     if (row != null)
                     {
-                        row.Cells[0].Value = true;
+                        row.Cells[CellIndexEnable].Value = true;
                         if (column.Zoom)
                         {
-                            row.Cells[1].Value = true;
+                            row.Cells[CellIndexZoom].Value = true;
                         }
 
-                        DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)(row.Cells[2]);
+                        DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)(row.Cells[CellIndexUnits]);
                         Conversion profileConversion = column.Conversion;
                         string profileUnits = column.Conversion.Units;
 
@@ -102,6 +109,8 @@ namespace PcmHacking
 
         private void parameterGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
+            // This ensures that checkbox changes are committed immediately.
+            // By default they are on committed when focus leaves the cell.
             DataGridViewCheckBoxCell checkBoxCell = this.parameterGrid.CurrentCell as DataGridViewCheckBoxCell;
             if ((checkBoxCell != null) && checkBoxCell.IsInEditMode && this.parameterGrid.IsCurrentCellDirty)
             {
@@ -111,6 +120,22 @@ namespace PcmHacking
 
         private void parameterGrid_CurrentCellDirtyStateChanged(object sender, EventArgs e)
         {
+            // Prevent the user from checking the Zoom box if the parameter is not
+            // enabled. I had hoped to disable the Zoom boxes until the corresponding
+            // parameter is enabled, but DataGridView doesn't support that.
+            if (this.parameterGrid.CurrentCell.ColumnIndex == CellIndexZoom)
+            {
+                int rowIndex = this.parameterGrid.CurrentCell.RowIndex;
+                DataGridViewCell enabledCell = this.parameterGrid.Rows[rowIndex].Cells[CellIndexEnable];
+                if ((bool)enabledCell.Value == false)
+                {
+                    this.parameterGrid.CancelEdit();
+                    return;
+                }
+            }
+
+            // This ensures that checkbox changes are committed immediately.
+            // By default they are on committed when focus leaves the cell.
             if (this.parameterGrid.IsCurrentCellDirty)
             {
                 this.parameterGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
@@ -144,12 +169,12 @@ namespace PcmHacking
 
             foreach (DataGridViewRow row in this.parameterGrid.Rows)
             {
-                if ((bool)row.Cells[0].Value == true)
+                if ((bool)row.Cells[CellIndexEnable].Value == true)
                 {
-                    Parameter parameter = (Parameter)row.Cells[1].Value;
+                    Parameter parameter = (Parameter)row.Cells[CellIndexParameter].Value;
                     Conversion conversion = null;
 
-                    DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)(row.Cells[2]);
+                    DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)(row.Cells[CellIndexUnits]);
                     foreach (Conversion candidate in cell.Items)
                     {
                         // The fact that we have to do both kinds of comparisons here really
@@ -162,7 +187,7 @@ namespace PcmHacking
                         }
                     }
 
-                    bool zoom = (bool)row.Cells[1].Value;
+                    bool zoom = (bool)row.Cells[CellIndexZoom].Value;
                     LogColumn column = new LogColumn(parameter, conversion, zoom);
                     this.currentProfile.AddColumn(column);
                 }
@@ -207,7 +232,7 @@ namespace PcmHacking
 
             foreach (DataGridViewRow row in this.parameterGrid.Rows)
             {
-                Parameter parameter = row.Cells[1].Value as Parameter;
+                Parameter parameter = row.Cells[CellIndexParameter].Value as Parameter;
                 if (parameter == null)
                 {
                     continue;

--- a/Apps/PcmLogger/MainForm.Zoom.cs
+++ b/Apps/PcmLogger/MainForm.Zoom.cs
@@ -10,8 +10,8 @@ namespace PcmHacking
     public partial class MainForm
     {
         private static Brush textBrush = Brushes.White;
-        private static Font bigFont = new Font("Arial", 32);
-        private static Font littleFont = new Font("Arial", 16);
+        private static Font bigFont = new Font("Arial", 80);
+        private static Font littleFont = new Font("Arial", 20);
         private const int topMargin = 10;
         private const int bottomMargin = -10;
 
@@ -26,17 +26,12 @@ namespace PcmHacking
 
         public void DrawZoomedParameters(List<ZoomedParameter> list)
         {
-            if (list.Count == 0)
-            {
-                return;
-            }
-
             var canvas = this.splitContainer2.Panel2;
             using (Graphics graphics = canvas.CreateGraphics())
             using (BufferedGraphics buffer = BufferedGraphicsManager.Current.Allocate(graphics, canvas.DisplayRectangle))
             {
                 buffer.Graphics.FillRectangle(new SolidBrush(Color.Black), canvas.DisplayRectangle);
-                int rowHeight = canvas.DisplayRectangle.Height / list.Count;
+                int rowHeight = canvas.DisplayRectangle.Height / Math.Max(1, list.Count);
 
                 for(int row = 0; row < list.Count; row++)
                 {

--- a/Apps/PcmLogger/MainForm.Zoom.cs
+++ b/Apps/PcmLogger/MainForm.Zoom.cs
@@ -33,8 +33,14 @@ namespace PcmHacking
                 buffer.Graphics.FillRectangle(new SolidBrush(Color.Black), canvas.DisplayRectangle);
                 int rowHeight = canvas.DisplayRectangle.Height / Math.Max(1, list.Count);
 
-                for(int row = 0; row < list.Count; row++)
+                for (int row = 0; row < list.Count; row++)
                 {
+                    if ((row & 1) > 0)
+                    {
+                        int topY = row * rowHeight;
+                        buffer.Graphics.FillRectangle(new SolidBrush(Color.FromArgb(32, 32, 32)), 0, topY, canvas.Width, rowHeight);
+                    }
+                    
                     int centerX = canvas.DisplayRectangle.Width / 2;
                     int centerY = ((rowHeight) / 2) + row * rowHeight;
 

--- a/Apps/PcmLogger/MainForm.Zoom.cs
+++ b/Apps/PcmLogger/MainForm.Zoom.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PcmHacking
+{
+    public partial class MainForm
+    {
+        private static Brush textBrush = Brushes.White;
+        private static Font bigFont = new Font("Arial", 32);
+        private static Font littleFont = new Font("Arial", 16);
+        private const int margin = 5;
+        
+        public void ClearZoomPanel()
+        {
+            var canvas = this.splitContainer2.Panel2;
+            using (var graphics = canvas.CreateGraphics())
+            {
+                graphics.FillRectangle(new SolidBrush(Color.Black), canvas.DisplayRectangle);
+            }
+        }
+
+        public void DrawZoomedParameters(List<ZoomedParameter> list)
+        {
+            
+            var canvas = this.splitContainer2.Panel2;
+            using (var graphics = canvas.CreateGraphics())
+            using (var buffer = BufferedGraphicsManager.Current.Allocate(graphics, canvas.DisplayRectangle))
+            {
+                graphics.FillRectangle(new SolidBrush(Color.Black), canvas.DisplayRectangle);
+                var rowHeight = canvas.DisplayRectangle.Height / list.Count;
+
+                for(int row = 0; row < list.Count; row++)
+                {
+                    var centerX = canvas.DisplayRectangle.Width / 2;
+                    var centerY = ((rowHeight) / 2) + row * rowHeight;
+
+                    StringFormat format = new StringFormat();
+
+                    string valueString = list[row].Value;
+                    SizeF valueSize = buffer.Graphics.MeasureString(valueString, bigFont);
+                    float valueX = centerX - valueSize.Width / 2;
+                    float valueY = centerY - valueSize.Height / 2;
+                    buffer.Graphics.DrawString(valueString, bigFont, textBrush, valueX, valueY, format);
+
+                    string nameString = list[row].Name;
+                    SizeF nameSize = buffer.Graphics.MeasureString(nameString, littleFont);
+                    float nameX = centerX - nameSize.Width / 2;
+                    float nameY = centerY - ((valueSize.Height / 2) + nameSize.Width / 2 + margin);
+                    buffer.Graphics.DrawString(nameString, littleFont, textBrush, nameX, nameY, format);
+
+                    string unitsString = list[row].Units;
+                    SizeF unitsSize = buffer.Graphics.MeasureString(unitsString, littleFont);
+                    float unitsX = centerX - unitsSize.Width / 2;
+                    float unitsY = centerY + (valueSize.Height / 2) + margin;
+                    buffer.Graphics.DrawString(unitsString, littleFont, textBrush, unitsX, unitsY, format);
+                }
+
+                buffer.Render();
+            }
+
+        }
+    }
+}

--- a/Apps/PcmLogger/MainForm.Zoom.cs
+++ b/Apps/PcmLogger/MainForm.Zoom.cs
@@ -12,8 +12,9 @@ namespace PcmHacking
         private static Brush textBrush = Brushes.White;
         private static Font bigFont = new Font("Arial", 32);
         private static Font littleFont = new Font("Arial", 16);
-        private const int margin = 5;
-        
+        private const int topMargin = 10;
+        private const int bottomMargin = -10;
+
         public void ClearZoomPanel()
         {
             var canvas = this.splitContainer2.Panel2;
@@ -25,18 +26,22 @@ namespace PcmHacking
 
         public void DrawZoomedParameters(List<ZoomedParameter> list)
         {
-            
-            var canvas = this.splitContainer2.Panel2;
-            using (var graphics = canvas.CreateGraphics())
-            using (var buffer = BufferedGraphicsManager.Current.Allocate(graphics, canvas.DisplayRectangle))
+            if (list.Count == 0)
             {
-                graphics.FillRectangle(new SolidBrush(Color.Black), canvas.DisplayRectangle);
-                var rowHeight = canvas.DisplayRectangle.Height / list.Count;
+                return;
+            }
+
+            var canvas = this.splitContainer2.Panel2;
+            using (Graphics graphics = canvas.CreateGraphics())
+            using (BufferedGraphics buffer = BufferedGraphicsManager.Current.Allocate(graphics, canvas.DisplayRectangle))
+            {
+                buffer.Graphics.FillRectangle(new SolidBrush(Color.Black), canvas.DisplayRectangle);
+                int rowHeight = canvas.DisplayRectangle.Height / list.Count;
 
                 for(int row = 0; row < list.Count; row++)
                 {
-                    var centerX = canvas.DisplayRectangle.Width / 2;
-                    var centerY = ((rowHeight) / 2) + row * rowHeight;
+                    int centerX = canvas.DisplayRectangle.Width / 2;
+                    int centerY = ((rowHeight) / 2) + row * rowHeight;
 
                     StringFormat format = new StringFormat();
 
@@ -49,13 +54,13 @@ namespace PcmHacking
                     string nameString = list[row].Name;
                     SizeF nameSize = buffer.Graphics.MeasureString(nameString, littleFont);
                     float nameX = centerX - nameSize.Width / 2;
-                    float nameY = centerY - ((valueSize.Height / 2) + nameSize.Width / 2 + margin);
+                    float nameY = centerY - ((valueSize.Height / 2) + nameSize.Height / 2 + topMargin);
                     buffer.Graphics.DrawString(nameString, littleFont, textBrush, nameX, nameY, format);
 
                     string unitsString = list[row].Units;
                     SizeF unitsSize = buffer.Graphics.MeasureString(unitsString, littleFont);
                     float unitsX = centerX - unitsSize.Width / 2;
-                    float unitsY = centerY + (valueSize.Height / 2) + margin;
+                    float unitsY = centerY + (valueSize.Height / 2) + bottomMargin;
                     buffer.Graphics.DrawString(unitsString, littleFont, textBrush, unitsX, unitsY, format);
                 }
 

--- a/Apps/PcmLogger/MainForm.resx
+++ b/Apps/PcmLogger/MainForm.resx
@@ -145,22 +145,4 @@ Thanks!
   <metadata name="canParameterUnitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="canParameterNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="canParameterUnitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="enabledColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Zoom.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="unitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
 </root>

--- a/Apps/PcmLogger/MainForm.resx
+++ b/Apps/PcmLogger/MainForm.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="canParameterNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="canParameterUnitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <data name="disclaimer.Text" xml:space="preserve">
     <value>Please keep in mind that this software is still in development. 
 
@@ -139,10 +145,16 @@ Thanks!
   <metadata name="unitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="canParameterNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="enabledColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="canParameterUnitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="Zoom.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="unitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>

--- a/Apps/PcmLogger/MainForm.resx
+++ b/Apps/PcmLogger/MainForm.resx
@@ -130,6 +130,9 @@ Thanks!
   <metadata name="enabledColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="Zoom.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -140,6 +143,24 @@ Thanks!
     <value>True</value>
   </metadata>
   <metadata name="canParameterUnitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="canParameterNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="canParameterUnitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="enabledColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Zoom.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="unitsColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>

--- a/Apps/PcmLogger/Parameters.Math.xml
+++ b/Apps/PcmLogger/Parameters.Math.xml
@@ -8,7 +8,7 @@
       xParameterConversion="g/s"
       yParameterId="EngineSpeed"
       yParameterConversion="RPM">
-    <Conversion units="g/cyl" expression="x*15.0/(y*2)" format="0.00" />
+    <Conversion units="g/cyl" expression="x*30.0/y" format="0.00" />
   </MathParameter>
  <MathParameter
       id="MathIdcBank1"

--- a/Apps/PcmLogger/Parameters.Standard.xml
+++ b/Apps/PcmLogger/Parameters.Standard.xml
@@ -1070,13 +1070,53 @@
   </Parameter>
 
   <Parameter
+      id="MisfireCurrentCyl1"
+      pid="1201"
+      name="Misfire Current Cyl 1"
+      description=""
+      storageType="uint8"
+      bitMapped="False">
+    <Conversion units="Raw" expression="x" format="0" />
+    <OS id="all" />
+  </Parameter>
+  <Parameter
+      id="MisfireCurrentCyl2"
+      pid="1202"
+      name="Misfire Current Cyl 2"
+      description=""
+      storageType="uint8"
+      bitMapped="False">
+    <Conversion units="Raw" expression="x" format="0" />
+    <OS id="all" />
+  </Parameter>
+  <Parameter
+      id="MisfireCurrentCyl3"
+      pid="1203"
+      name="Misfire Current Cyl 3"
+      description=""
+      storageType="uint8"
+      bitMapped="False">
+    <Conversion units="Raw" expression="x" format="0" />
+    <OS id="all" />
+  </Parameter>
+  <Parameter
+      id="MisfireCurrentCyl4"
+      pid="1204"
+      name="Misfire Current Cyl 4"
+      description=""
+      storageType="uint8"
+      bitMapped="False">
+    <Conversion units="Raw" expression="x" format="0" />
+    <OS id="all" />
+  </Parameter>
+  <Parameter
       id="MisfireCurrentCyl5"
       pid="11EA"
       name="Misfire Current Cyl 5"
       description=""
       storageType="uint8"
       bitMapped="False">
-    <Conversion units="Boolean" expression="x" format="0.00" />
+    <Conversion units="Raw" expression="x" format="0" />
     <OS id="all" />
   </Parameter>
   <Parameter
@@ -1086,7 +1126,7 @@
       description=""
       storageType="uint8"
       bitMapped="False">
-    <Conversion units="Boolean" expression="x" format="0.00" />
+    <Conversion units="Raw" expression="x" format="0" />
     <OS id="all" />
   </Parameter>
   <Parameter
@@ -1096,7 +1136,7 @@
       description=""
       storageType="uint8"
       bitMapped="False">
-    <Conversion units="Boolean" expression="x" format="0.00" />
+    <Conversion units="Raw" expression="x" format="0" />
     <OS id="all" />
   </Parameter>
   <Parameter
@@ -1145,46 +1185,6 @@
       name="Misfire History Cyl 8"
       description=""
       storageType="uint16"
-      bitMapped="False">
-    <Conversion units="Raw" expression="x" format="0" />
-    <OS id="all" />
-  </Parameter>
-  <Parameter
-      id="MisfireCurrentCyl1"
-      pid="1201"
-      name="Misfire Current Cyl 1"
-      description=""
-      storageType="uint8"
-      bitMapped="False">
-    <Conversion units="Raw" expression="x" format="0" />
-    <OS id="all" />
-  </Parameter>
-  <Parameter
-      id="MisfireCurrentCyl2"
-      pid="1202"
-      name="Misfire Current Cyl 2"
-      description=""
-      storageType="uint8"
-      bitMapped="False">
-    <Conversion units="Raw" expression="x" format="0" />
-    <OS id="all" />
-  </Parameter>
-  <Parameter
-      id="MisfireCurrentCyl3"
-      pid="1203"
-      name="Misfire Current Cyl 3"
-      description=""
-      storageType="uint8"
-      bitMapped="False">
-    <Conversion units="Raw" expression="x" format="0" />
-    <OS id="all" />
-  </Parameter>
-  <Parameter
-      id="MisfireCurrentCyl4"
-      pid="1204"
-      name="Misfire Current Cyl 4"
-      description=""
-      storageType="uint8"
       bitMapped="False">
     <Conversion units="Raw" expression="x" format="0" />
     <OS id="all" />

--- a/Apps/PcmLogger/Parameters.Standard.xml
+++ b/Apps/PcmLogger/Parameters.Standard.xml
@@ -651,7 +651,7 @@
       storageType="uint8"
       bitMapped="True"
       bitIndex="6">
-    <Conversion units="Boolean" expression="Presed,Relased" format="0" />
+    <Conversion units="Boolean" expression="Pressed,Relased" format="0" />
     <OS id="all" />
   </Parameter>
   <Parameter
@@ -984,7 +984,7 @@
       description=""
       storageType="uint8"
       bitMapped="False">
-    <Conversion units="Boolean" expression="x" format="0.00" />
+    <Conversion units="Index" expression="x" format="0.00" />
     <OS id="all" />
   </Parameter>
   <Parameter

--- a/Apps/PcmLogger/PcmLogger.csproj
+++ b/Apps/PcmLogger/PcmLogger.csproj
@@ -69,9 +69,7 @@
     <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MainForm.LoggingThread.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Include="MainForm.LoggingThread.cs" />
     <Compile Include="MainForm.ParameterGrid.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -86,6 +84,9 @@
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
     <Compile Include="MainForm.Can.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="MainForm.Zoom.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="PathDisplayAdapter.cs" />

--- a/Apps/Tests/LoggingTests.cs
+++ b/Apps/Tests/LoggingTests.cs
@@ -27,10 +27,10 @@ namespace Tests
             Parameter signed16 =   new RamParameter("U8",  "signed 16-bit",   "", "int16",  false, conversions, GetAddress(0));
             Parameter unsigned16 = new RamParameter("U16", "unsigned 16-bit", "", "uint16", false, conversions, GetAddress(0));
 
-            LogColumn signed8Column = new LogColumn(signed8, conversion);
-            LogColumn unsigned8Column = new LogColumn(unsigned8, conversion);
-            LogColumn signed16Column = new LogColumn(signed16, conversion);
-            LogColumn unsigned16Column = new LogColumn(unsigned16, conversion);
+            LogColumn signed8Column = new LogColumn(signed8, conversion, false);
+            LogColumn unsigned8Column = new LogColumn(unsigned8, conversion, false);
+            LogColumn signed16Column = new LogColumn(signed16, conversion, false);
+            LogColumn unsigned16Column = new LogColumn(unsigned16, conversion, false);
 
             ParameterGroup group = new ParameterGroup(0);
 

--- a/Apps/Tests/MathTests.cs
+++ b/Apps/Tests/MathTests.cs
@@ -16,13 +16,15 @@ namespace Tests
             LogColumn rpm = new LogColumn(
                 new PidParameter("EngSpeed", "Engine Speed", "", "uint16", false, 
                     new Conversion[] { rpmConversion }, 0x3456, new List<uint>()),
-                rpmConversion);
+                rpmConversion,
+                false);
 
             Conversion mafConversion = new Conversion("RPM", "x", "0");
             LogColumn maf = new LogColumn(
                 new PidParameter("MAF", "Mass Air Flow", "", "uint16", false,
                     new Conversion[] { mafConversion }, 0x1234, new List<uint>()),
-                mafConversion);
+                mafConversion,
+                false);
 
             MathParameter load = new MathParameter(
                 "id",
@@ -32,7 +34,7 @@ namespace Tests
                 rpm,
                 maf);
 
-            LogColumn mathColumn = new LogColumn(load, load.Conversions.First());
+            LogColumn mathColumn = new LogColumn(load, load.Conversions.First(), false);
 
             DpidConfiguration profile = new DpidConfiguration();
             profile.ParameterGroups.Add(new ParameterGroup(0xFE));


### PR DESCRIPTION
This picture tells the story pretty well:
![image](https://github.com/user-attachments/assets/255900e3-496e-4b88-a222-2e8eb1b9343c)

That's fake data from the PCM on my workbench, but you get the idea. I wanted to be able to glance at my laptop to see MAP and Load once in a while, and now that's practical.

To select which parameters appear in the new pane, there's a new "Zoom" column in the parameter grid. You can only check these boxes for parameters that are already being logged.


