### PR TITLE
Fix P10 image size != flash size special case. Fix spelling. Remove s…

### DIFF
--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -1556,7 +1556,7 @@ namespace PcmHacking
                     if (pcmInfo.HardwareSlaveCPU == true && !pcmInfo.IsSupportedWriteSlaveCPU && (writeType == WriteType.Full || writeType == WriteType.OsPlusCalibrationPlusBoot))
                     {
                         string msg = $"Warning: Writes to the {pcmInfo.HardwareType.ToString()} slave CPU are not supported." + Environment.NewLine +
-                                    "You must have another way to update the slave CPU to match when you change operating system, else electroncic throttle may not work." + Environment.NewLine +
+                                    "You must have another way to update the slave CPU to match when you change operating system, else electronic throttle may not work." + Environment.NewLine +
                                     "Restore this PCM to its original operating system if this happens.";
                         this.AddUserMessage(msg);
                         DialogResult dialogResult = MessageBox.Show(msg, "Warning!", MessageBoxButtons.YesNo);
@@ -1570,23 +1570,6 @@ namespace PcmHacking
                             this.AddUserMessage("User chose to proceed.");
                         }
                     }
-
-                    /*if (pcmInfo.HardwareType == PcmType.E54)
-                    {
-                        string msg = $"WARNING: {pcmInfo.HardwareType.ToString()} support is insufficiently tested, but believed to be working." + Environment.NewLine +
-                                    "Please report success or failure on pcmhacking.net." + Environment.NewLine +
-                                    "Do you accept the risk of damage to your hardware?";
-                        this.AddUserMessage(msg);
-                        DialogResult dialogResult = MessageBox.Show(msg, "Continue?", MessageBoxButtons.YesNo);
-                        if (dialogResult == DialogResult.No)
-                        {
-                            this.AddUserMessage("User chose not to proceed.");
-                            return;
-                        }else
-                        {
-                            this.AddUserMessage("User accepts the risk of running insufficiently tested code.");
-                        }
-                    }*/
 
                     await this.Vehicle.SuppressChatter();
 

--- a/Apps/PcmLibrary/CKernelWriter.cs
+++ b/Apps/PcmLibrary/CKernelWriter.cs
@@ -248,7 +248,7 @@ namespace PcmHacking
 
             // This is the only thing preventing a P01 os write to a P59 or vice-versa because of the shared P01_P59 type
             // But a P10 has a 1Mb chip that is only 512Kb used, so that can be allowed.
-            if ((pcmInfo.HardwareType == PcmType.P10 && image.Length == 512 * 1024 || flashChip.Size == 1024 * 1024))
+            if (pcmInfo.HardwareType == PcmType.P10 && image.Length == 512 * 1024 && flashChip.Size == 1024 * 1024)
             {
                 this.logger.AddUserMessage(string.Format("File size {0:n0} for flash chip size {1:n0}. Allowable for P10.", image.Length, flashChip.Size));
             }


### PR DESCRIPTION
Fix P10 exception logic which allows 512Kb P10 image file to be written to a 1Mbyte P10 PCM. Implementation fixes and correctly blocks attempts to write P01 512Kb image file to P59 1Mbyte PCM.

Fix spelling error.

Remove unused E54 warning code.