### PR TITLE
Moved VIN validation logic out of PcmHammer and into PcmLibrary

### DIFF
--- a/Apps/PcmHammer/DialogBoxes/VinForm.cs
+++ b/Apps/PcmHammer/DialogBoxes/VinForm.cs
@@ -80,128 +80,37 @@ namespace PcmHacking.DialogBoxes
 
             if (this.vinBox.Text.Length != 17)
             {
-                this.prompt.Text = $"The VIN must be 17 characters long! This is {this.vinBox.Text.Length}.";
-                return false;
-            }
-
-            if (!VinForm.IsAlphaNumeric(this.vinBox.Text))
-            {
-                this.prompt.Text = "The VIN must contain only letters and numbers.";
+                this.prompt.Text = $"The VIN must be 17 characters long.\nThis is {this.vinBox.Text.Length} characters.";
                 return false;
             }
 
             this.vinBox.Text = this.vinBox.Text.ToUpper();
 
-            if (IsVinChecksumOK(this.vinBox.Text))
+            int invalidCharacterIndex = -1;
+            char requiredCheckDigit = 'X';
+            if (VinValidator.IsValid(this.vinBox.Text, out invalidCharacterIndex, out requiredCheckDigit))
             {
                 this.prompt.Text = "The VIN is valid. Good!";
                 return true;
             }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Find out if the whole VIN string is alphanumeric.
-        /// </summary>
-        private static bool IsAlphaNumeric(string vin)
-        {
-            foreach(char c in vin)
-            {
-                if(!char.IsLetterOrDigit(c))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-
-        private bool IsVinChecksumOK(string vin)
-        {
-        // Array of VIN character position weight factors:
-        ushort[] CharWeight = new ushort[] { 8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2 };
-        ushort checksum = 0;
-            for(int i = 0; i < 17; i++)
-            {
-                ushort digitVal = CharWeight[i];
-                if (char.IsDigit(vin[i]))
-                {
-                    digitVal *= ((ushort)char.GetNumericValue(vin[i]));
-                }
-                else
-                {
-                    switch (char.ToUpper(vin[i]))
-                    {
-                        case 'A':
-                        case 'J':
-                            digitVal *= 1;
-                            break;
-                        case 'B':
-                        case 'K':
-                        case 'S':
-                            digitVal *= 2;
-                            break;
-                        case 'C':
-                        case 'L':
-                        case 'T':
-                            digitVal *= 3;
-                            break;
-                        case 'D':
-                        case 'M':
-                        case 'U':
-                            digitVal *= 4;
-                            break;
-                        case 'E':
-                        case 'N':
-                        case 'V':
-                            digitVal *= 5;
-                            break;
-                        case 'F':
-                        case 'W':
-                            digitVal *= 6;
-                            break;
-                        case 'G':
-                        case 'P':
-                        case 'X':
-                            digitVal *= 7;
-                            break;
-                        case 'H':
-                        case 'Y':
-                            digitVal *= 8;
-                            break;
-                        case 'R':
-                        case 'Z':
-                            digitVal *= 9;
-                            break;
-                        default:
-                            this.prompt.Text = $"The VIN contains invalid character '{vin[i]}' on position {i+1}.";
-                            return false;
-                    }
-                }
-                checksum += digitVal;
-            }
-
-            checksum %= 11;
-
-            char CheckDigit = 'X';
-
-            if(checksum < 10)
-            {
-                CheckDigit = checksum.ToString()[0];
-            }
-
-            if (vin[8] == CheckDigit)
-            {
-                return true;
-            }
             else
             {
-                this.prompt.Text = $"The VIN check digit on position 9 is incorrect!\nCorrect check digit is: {CheckDigit}";
+                if (invalidCharacterIndex >= 0)
+                {
+                    char invalidCharacter = this.vinBox.Text[invalidCharacterIndex];
+                    this.prompt.Text = $"The \"{invalidCharacter}\" at position {invalidCharacterIndex + 1} is not a letter or number.";
+                    return false;
+                }
+
+                if (requiredCheckDigit != 'X')
+                {
+                    this.prompt.Text = $"The VIN check digit on position 9 is incorrect.\nCorrect check digit is: {requiredCheckDigit}";
+                    return false;
+                }
+
+                this.prompt.Text = "The VIN is invalid.";
                 return false;
             }
         }
-
     }
 }

--- a/Apps/PcmLibrary/Misc/VinValidator.cs
+++ b/Apps/PcmLibrary/Misc/VinValidator.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PcmHacking
+{
+    public class VinValidator
+    {
+        public static bool IsValid(string vin, out int invalidCharacterIndex, out char requiredCheckDigit)
+        {
+            invalidCharacterIndex = -1;
+            requiredCheckDigit = 'X';
+
+            // Array of VIN character position weight factors:
+            ushort[] CharWeight = new ushort[] { 8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2 };
+            ushort checksum = 0;
+            for (int i = 0; i < 17; i++)
+            {
+                ushort digitVal = CharWeight[i];
+                if (char.IsDigit(vin[i]))
+                {
+                    digitVal *= ((ushort)char.GetNumericValue(vin[i]));
+                }
+                else
+                {
+                    switch (char.ToUpper(vin[i]))
+                    {
+                        case 'A':
+                        case 'J':
+                            digitVal *= 1;
+                            break;
+                        case 'B':
+                        case 'K':
+                        case 'S':
+                            digitVal *= 2;
+                            break;
+                        case 'C':
+                        case 'L':
+                        case 'T':
+                            digitVal *= 3;
+                            break;
+                        case 'D':
+                        case 'M':
+                        case 'U':
+                            digitVal *= 4;
+                            break;
+                        case 'E':
+                        case 'N':
+                        case 'V':
+                            digitVal *= 5;
+                            break;
+                        case 'F':
+                        case 'W':
+                            digitVal *= 6;
+                            break;
+                        case 'G':
+                        case 'P':
+                        case 'X':
+                            digitVal *= 7;
+                            break;
+                        case 'H':
+                        case 'Y':
+                            digitVal *= 8;
+                            break;
+                        case 'R':
+                        case 'Z':
+                            digitVal *= 9;
+                            break;
+                        default:
+                            invalidCharacterIndex = i;
+                            return false;
+                    }
+                }
+                checksum += digitVal;
+            }
+
+            checksum %= 11;
+
+            char CheckDigit = 'X';
+
+            if (checksum < 10)
+            {
+                CheckDigit = checksum.ToString()[0];
+            }
+
+            if (vin[8] == CheckDigit)
+            {
+                return true;
+            }
+            else
+            {
+                requiredCheckDigit = CheckDigit;
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm working on the VIN-change feature in the Uno Platform branch, and I want to re-use the validation code that we already have... but the validation logic needs to move from PcmHammer.exe into PcmLibrary.dll so that both the current UI and new UI can share it. 

Along the way I noticed that the checksum validation code is looking for illegal (non-alphanumeric) characters, so we can leave out the IsAlphaNumeric() function. The checksum code does a little bit better job anyway, since it tells the user which character was illegal.