### PR TITLE
Enable 'Start Recording' button after re-starting logger.

### DIFF
--- a/Apps/PcmLibrary/Logging/Logger.cs
+++ b/Apps/PcmLibrary/Logging/Logger.cs
@@ -265,17 +265,25 @@ namespace PcmHacking
         /// </summary>
         public async Task<bool> StartLogging()
         {
-            this.dpids = await this.vehicle.ConfigureDpids(this.dpidConfiguration, this.osid);
-
-            if (this.dpids == null)
+            try
             {
-                return false;
+                this.dpids = await this.vehicle.ConfigureDpids(this.dpidConfiguration, this.osid);
+
+                if (this.dpids == null)
+                {
+                    return false;
+                }
+
+                // This part differs for the fast and slow loggers.
+                await this.StartLoggingInternal();
+                return true;
             }
-
-            // This part differs for the fast and slow loggers.
-            await this.StartLoggingInternal();
-
-            return true;
+            catch (Exception exception)
+            {
+                this.uiLogger.AddUserMessage("Unable to start logging: " + exception.Message);
+                this.uiLogger.AddDebugMessage(exception.ToString());
+                return false;
+            }            
         }
 
         protected abstract Task<bool> StartLoggingInternal();

--- a/Apps/PcmLogger/MainForm.LoggingThread.cs
+++ b/Apps/PcmLogger/MainForm.LoggingThread.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Runtime.CompilerServices;
-using System.Data;
-using System.Data.Common;
 
 namespace PcmHacking
 {
@@ -157,9 +154,16 @@ namespace PcmHacking
 
             Logger logger = this.Vehicle.CreateLogger(this.osid, canLogger, this.currentProfile.Columns, this);
 
-            if (!await logger.StartLogging())
+            try
             {
-                throw new LogStartFailedException();
+                if (!await logger.StartLogging())
+                {
+                    throw new LogStartFailedException();
+                }
+            }
+            catch (Exception exception)
+            {
+                throw new LogStartFailedException(exception.Message);
             }
 
             return logger;
@@ -317,6 +321,15 @@ namespace PcmHacking
                                                     this.AddUserMessage(exception.Message);
                                                     this.startStopSaving.Enabled = false;
                                                     this.logValues.Text = exception.Message;
+                                                });
+                                        }
+                                        else
+                                        {
+                                            this.loggerProgress.Invoke(
+                                                (MethodInvoker)
+                                                delegate ()
+                                                {
+                                                    this.startStopSaving.Enabled = true;
                                                 });
                                         }
                                     }

--- a/Apps/PcmLogger/MainForm.LoggingThread.cs
+++ b/Apps/PcmLogger/MainForm.LoggingThread.cs
@@ -154,16 +154,9 @@ namespace PcmHacking
 
             Logger logger = this.Vehicle.CreateLogger(this.osid, canLogger, this.currentProfile.Columns, this);
 
-            try
+            if (!await logger.StartLogging())
             {
-                if (!await logger.StartLogging())
-                {
-                    throw new LogStartFailedException();
-                }
-            }
-            catch (Exception exception)
-            {
-                throw new LogStartFailedException(exception.Message);
+                throw new LogStartFailedException();
             }
 
             return logger;


### PR DESCRIPTION
Someone reported that the Logger's "Start Recording" button never got enabled. Turns out that it only gets enabled if the app starts up with a good logging profile already configured. It should get enabled any time the logger starts logging.

Also added a try/catch so that Logger.StartLogging() will always return false if it can't start, which is what the UI layer expects (because it returns a boolean).
