### PR TITLE
Added some logging to help troubleshoot CAN issues.

### DIFF
--- a/Apps/PcmLibrary/Logging/CanLogger.cs
+++ b/Apps/PcmLibrary/Logging/CanLogger.cs
@@ -22,17 +22,20 @@ namespace PcmHacking
             }
         }
 
+        private readonly ParameterDatabase parameterDatabase;
+        private readonly ILogger logger;
+
         private IPort canPort;
         private CanParser parser = new CanParser();
         List<UInt32> keySnapshot = new List<UInt32>();
-        ParameterDatabase parameterDatabase;
 
         // Note that this is accessed by multiple threads, so it must only be used within "lock(messages)"
         Dictionary<UInt32, ParameterValue> messages = new Dictionary<uint, ParameterValue>();
 
-        public CanLogger(ParameterDatabase parameterDatabase)
+        public CanLogger(ParameterDatabase parameterDatabase, ILogger logger)
         {
             this.parameterDatabase = parameterDatabase;
+            this.logger = logger;
         }
 
         public void Dispose()
@@ -80,6 +83,11 @@ namespace PcmHacking
                 }
 
                 this.keySnapshot.Sort();
+                this.logger.AddUserMessage($"CanLogger found {keySnapshot.Count} CAN messages.");
+                foreach(UInt32 key in this.keySnapshot)
+                {
+                    this.logger.AddUserMessage($"CAN ID: {key:X}");
+                }
             }
         }
 

--- a/Apps/PcmLogger/MainForm.LoggingThread.cs
+++ b/Apps/PcmLogger/MainForm.LoggingThread.cs
@@ -140,7 +140,7 @@ namespace PcmHacking
         private async Task<Logger> RecreateLogger(ParameterDatabase parameterDatabase)
         {
             this.canLogger?.Dispose();
-            this.canLogger = new CanLogger(parameterDatabase);
+            this.canLogger = new CanLogger(parameterDatabase, this);
 
             if (string.IsNullOrEmpty(this.canPortName))
             {


### PR DESCRIPTION
Logging starts by sniffing the CAN bus for 1.5 seconds to see what messages IDs are available. It should then add those columns to the CSV file. Sometimes those columns don't show up, and this should help me figure out why.

Eventually I want to skip the "pause and sniff" step entirely, but I'm not quite there yet.