### PR TITLE
VPW 4x enable based on Scantool and ECU Type

### DIFF
--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -818,16 +818,7 @@ namespace PcmHacking
                     this.AddUserMessage("Hardware Type: " + pcmInfo.HardwareType.ToString());
                     if (pcmInfo.HardwareType == PcmType.P04)
                     {
-                        //Use this location to set whether a tool should be forced to use 1x!
-                        //OBDX Pro VT should be 1x due to P04 VPW load not high enough when on bench
-                        //Load is right in car, but car modules wake up and cause bus to crash to 1x regardless.
-                        if (Vehicle.DeviceDescription.Contains("OBDX Pro VT"))
-                        {
-                            this.AddUserMessage("OBDX Pro VT and P04 detected, 4x mode disabled.");
-                            Vehicle.Enable4xReadWrite = false;
-                           // DeviceConfiguration.Settings.Enable4xReadWrite = false; // turn off 4x for the VT!
-                        }
-
+                       
                         this.AddUserMessage("**********************************************");
                         this.AddUserMessage("WARNING: P04 Support is still in development.");
                         this.AddUserMessage("It may or may not read your P04 correctly.");
@@ -1287,7 +1278,7 @@ namespace PcmHacking
                         pcmInfo,
                         this);
 
-                    Response<Stream> readResponse = await reader.ReadContents(cancellationTokenSource.Token);
+                    Response<Stream> readResponse = await reader.ReadContents( cancellationTokenSource.Token);
 
                     this.AddUserMessage("Elapsed time " + DateTime.Now.Subtract(start));
                     if (readResponse.Status != ResponseStatus.Success)

--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -818,6 +818,16 @@ namespace PcmHacking
                     this.AddUserMessage("Hardware Type: " + pcmInfo.HardwareType.ToString());
                     if (pcmInfo.HardwareType == PcmType.P04)
                     {
+                        //Use this location to set whether a tool should be forced to use 1x!
+                        //OBDX Pro VT should be 1x due to P04 VPW load not high enough when on bench
+                        //Load is right in car, but car modules wake up and cause bus to crash to 1x regardless.
+                        if (Vehicle.DeviceDescription.Contains("OBDX Pro VT"))
+                        {
+                            this.AddUserMessage("OBDX Pro VT and P04 detected, 4x mode disabled.");
+                            Vehicle.Enable4xReadWrite = false;
+                           // DeviceConfiguration.Settings.Enable4xReadWrite = false; // turn off 4x for the VT!
+                        }
+
                         this.AddUserMessage("**********************************************");
                         this.AddUserMessage("WARNING: P04 Support is still in development.");
                         this.AddUserMessage("It may or may not read your P04 correctly.");

--- a/Apps/PcmLibrary/CKernelReader.cs
+++ b/Apps/PcmLibrary/CKernelReader.cs
@@ -37,7 +37,7 @@ namespace PcmHacking
         /// Read the full contents of the PCM.
         /// Assumes the PCM is unlocked and we're ready to go.
         /// </summary>
-        public async Task<Response<Stream>> ReadContents(CancellationToken cancellationToken)
+        public async Task<Response<Stream>> ReadContents( CancellationToken cancellationToken)
         {
             try
             {
@@ -49,7 +49,7 @@ namespace PcmHacking
                 if (this.vehicle.Enable4xReadWrite)
                 {
                     // if the vehicle bus switches but the device does not, the bus will need to time out to revert back to 1x, and the next steps will fail.
-                    if (!await this.vehicle.VehicleSetVPW4x(VpwSpeed.FourX))
+                    if (!await this.vehicle.VehicleSetVPW4x(this.pcmInfo, VpwSpeed.FourX))
                     {
                         this.logger.AddUserMessage("Stopping here because we were unable to switch to 4X.");
                         return Response.Create(ResponseStatus.Error, (Stream)null);
@@ -267,7 +267,9 @@ namespace PcmHacking
                     (payloadMessage) => this.protocol.ParsePayload(payloadMessage, length, startAddress),
                     cancellationToken);
 
-                if(readResponse.Status != ResponseStatus.Success)
+               
+
+                if (readResponse.Status != ResponseStatus.Success)
                 {
                     this.logger.AddDebugMessage("Unable to read segment: " + readResponse.Status);
                     continue;

--- a/Apps/PcmLibrary/CKernelWriter.cs
+++ b/Apps/PcmLibrary/CKernelWriter.cs
@@ -65,7 +65,7 @@ namespace PcmHacking
                     if (this.vehicle.Enable4xReadWrite)
                     {
                         // if the vehicle bus switches but the device does not, the bus will need to time out to revert back to 1x, and the next steps will fail.
-                        if (!await this.vehicle.VehicleSetVPW4x(VpwSpeed.FourX))
+                        if (!await this.vehicle.VehicleSetVPW4x(this.pcmInfo ,VpwSpeed.FourX))
                         {
                             this.logger.AddUserMessage("Stopping here because we were unable to switch to 4X.");
                             return false;

--- a/Apps/PcmLibrary/Devices/OBDXProDevice.cs
+++ b/Apps/PcmLibrary/Devices/OBDXProDevice.cs
@@ -24,6 +24,8 @@ namespace PcmHacking
         public bool TimeStampsEnabled = false;
         public bool CRCInReceivedFrame = false;
 
+        
+
         // This default is probably excessive but it should always be
         // overwritten by a call to SetTimeout before use anyhow.
         private VpwSpeed vpwSpeed = VpwSpeed.Standard;
@@ -101,7 +103,7 @@ namespace PcmHacking
 
         public override string GetDeviceType()
         {
-            return DeviceType;
+            return ToolConnected == "" ? DeviceType : ToolConnected;         
         }
 
         public override async Task<bool> Initialize()

--- a/Apps/PcmLibrary/Devices/OBDXProDevice.cs
+++ b/Apps/PcmLibrary/Devices/OBDXProDevice.cs
@@ -203,7 +203,7 @@ namespace PcmHacking
         {
             if (timeout == 0)
             {
-                timeout = 500;
+                timeout = 1000;
             }
 
             int TempCount = 0;

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -449,7 +449,7 @@ namespace PcmHacking
         /// <summary>
         /// Does everything required to switch to VPW 4x
         /// </summary>
-        public async Task<bool> VehicleSetVPW4x(VpwSpeed newSpeed)
+        public async Task<bool> VehicleSetVPW4x(PcmInfo info, VpwSpeed newSpeed)
         {
             if (!device.Supports4X) 
             {
@@ -460,6 +460,22 @@ namespace PcmHacking
                 }
                 return true;
             }
+
+            //Use this location to set whether a tool should be forced to use 1x!
+            //OBDX Pro VT should be 1x due to P04 VPW load not high enough when on bench
+            //Load is right in car, but car modules wake up and cause bus to crash to 1x regardless.
+            if (info.HardwareType == PcmType.P04)
+            {
+                if (this.device.ToString().Contains("OBDX Pro VT"))
+                {
+                    this.device.Enable4xReadWrite = false;
+                    // DeviceConfiguration.Settings.Enable4xReadWrite = false; // turn off 4x for the VT!
+                    return true;
+                }
+            }
+          
+
+
 
             if ((newSpeed == VpwSpeed.FourX) && !this.device.Enable4xReadWrite)
             {


### PR DESCRIPTION
These change were originally submitted here: https://github.com/LegacyNsfw/PcmHacks/pull/337

I didn't notice at the time, but I wish this had gotten merged one way or the other.
I think it's worth tidying this up (as per the notes in the original PR) and merging it.
Or maybe even just merging it. I haven't actually looked at it yet.

Edit: can't "just merge it" because the changes sat for so long that the base code has changed. :( 