### PR TITLE
Fix blackbox checksums

### DIFF
--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -11,6 +11,32 @@ namespace PcmHacking
     public class FileValidator
     {
         /// <summary>
+        /// Names of segments in P10 operating systems.
+        /// </summary>
+        private readonly string[] segmentNames_P10 =
+        {
+            "Operating system",
+            "Engine calibration",
+            "Transmission calibration",
+            "System",
+            "Speedometer",
+        };
+
+        /// <summary>
+        /// Names of segments in BlackBox operating systems.
+        /// </summary>
+        private readonly string[] segmentNames_BlackBox =
+        {
+            "Operating system",
+            "Engine calibration",
+            "Fuel system",
+            "System",
+            "Speedometer",
+            "VIN",
+            "Transmission calibration",
+        };
+
+        /// <summary>
         /// Names of segments in P01 and P59 operating systems.
         /// </summary>
         private readonly string[] segmentNames_P01_P59 =
@@ -21,18 +47,6 @@ namespace PcmHacking
             "Transmission calibration",
             "Transmission diagnostics",
             "Fuel system",
-            "System",
-            "Speedometer",
-        };
-
-        /// <summary>
-        /// Names of segments in P10 operating systems.
-        /// </summary>
-        private readonly string[] segmentNames_P10 =
-        {
-            "Operating system",
-            "Engine calibration",
-            "Transmission calibration",
             "System",
             "Speedometer",
         };
@@ -231,7 +245,7 @@ namespace PcmHacking
 
                 case PcmType.BlackBox:
                     tableAddress = 0x2000C;
-                    segments = 5;
+                    segments = 7;
                     break;
 
                 // no segment table
@@ -323,6 +337,10 @@ namespace PcmHacking
                         {
                             case PcmType.P10:
                                 segmentName = segmentNames_P10[segment];
+                                break;
+
+                            case PcmType.BlackBox:
+                                segmentName = segmentNames_BlackBox[segment];
                                 break;
 
                             default:


### PR DESCRIPTION
Before (wrong order and missing segments)

[08:38:46:850]  	Start	End	Stored	Needed	Verdict	Segment Name
[08:38:46:858]  	20002	66F63	81E3	81E3	Good	Operating system
[08:38:46:865]  	08002	0E651	0EF1	0EF1	Good	Engine calibration
[08:38:46:873]  	0E654	0EF93	1205	1205	Good	Engine diagnostics.
[08:38:46:881]  	0EF96	0F0D1	9B19	9B19	Good	Transmission calibration
[08:38:46:890]  	0F0D4	0F109	6EE4	6EE4	Good	Transmission diagnostics

After (all segments, correct names)

[01:56:59:136]  Identifying 512KiB file.
[01:56:59:142]  File is Vortec BlackBox 512KiB.
[01:56:59:149]  File operating system ID: 9365095
[01:56:59:157]  File is Vortec BlackBox 512KiB.
[01:56:59:159]  	Start	End	Stored	Needed	Verdict	Segment Name
[01:56:59:163]  	20002	66F63	81E3	81E3	Good	Operating system
[01:56:59:168]  	08002	0E651	0EF1	0EF1	Good	Engine calibration
[01:56:59:179]  	0E654	0EF93	1205	1205	Good	Fuel system
[01:56:59:186]  	0EF96	0F0D1	9B19	9B19	Good	System
[01:56:59:195]  	0F0D4	0F109	6EE4	6EE4	Good	Speedometer
[01:56:59:203]  	14900	1491D	E9F8	E9F8	Good	VIN
[01:56:59:212]  	0F10C	148FD	D52A	D52A	Good	Transmission calibration
[01:56:59:219]  All checksums are valid.