### PR TITLE
Configure Uno UI to target 32-bit Windows build.

### DIFF
--- a/.github/workflows/CheckBuild.yml
+++ b/.github/workflows/CheckBuild.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Create temporary artifact storage
       run: |
         mkdir TemporaryArtifactStorage
-        mkdir TemporaryArtifactStorage/Skia
         mkdir TemporaryArtifactStorage/WindowsUnpackaged
 
     - name: Build C Kernels
@@ -86,9 +85,8 @@ jobs:
           fi
         done
 
-    - name: Copy kernels into Skia and WindowsUnpackaged folders
+    - name: Copy kernels into WindowsUnpackaged folder
       run: |
-        cp TemporaryArtifactStorage/*.bin TemporaryArtifactStorage/Skia
         cp TemporaryArtifactStorage/*.bin TemporaryArtifactStorage/WindowsUnpackaged
 
     - name: Upload artifacts
@@ -161,23 +159,14 @@ jobs:
         Copy-Item -Path "Apps/UI/WindowsForms/VpwExplorer/bin/Debug/*.dll" -Destination TemporaryArtifactStorage
         Copy-Item -Path "Apps/UI/WindowsForms/VpwExplorer/bin/Debug/*.pdb" -Destination TemporaryArtifactStorage
 
-    - name: Add Uno Skia binaries to temporary artifact storage (until proper Windows builds work)
-      run: |
-        Copy-Item -Recurse -Path "Apps/UI/UnoUI/PcmHacking.UnoUI/bin/Debug/net10.0-desktop/*" -Destination TemporaryArtifactStorage/Skia
-        Copy-Item -Path "Apps/UI/WindowsForms/PcmLogger/*.LogProfile"     -Destination TemporaryArtifactStorage/Skia
-        Copy-Item -Path "Apps/UI/WindowsForms/PcmLogger/Parameters.*.xml" -Destination TemporaryArtifactStorage/Skia
-
     - name: Add Uno Windows binaries to temporary artifact storage
       run: |
-        Copy-Item -Recurse -Path "Apps/UI/UnoUI/PcmHacking.UnoUI/bin/Debug/net10.0-windows10.0.26100.0/*" -Destination TemporaryArtifactStorage/WindowsUnpackaged
+        Copy-Item -Recurse -Path "Apps/UI/UnoUI/PcmHacking.UnoUI/bin/x86/Debug/net10.0-windows10.0.26100.0/win-x86/*" -Destination TemporaryArtifactStorage/WindowsUnpackaged
         Copy-Item -Path "Apps/UI/WindowsForms/PcmLogger/*.LogProfile"     -Destination TemporaryArtifactStorage/WindowsUnpackaged
         Copy-Item -Path "Apps/UI/WindowsForms/PcmLogger/Parameters.*.xml" -Destination TemporaryArtifactStorage/WindowsUnpackaged
 
     - name: Is it all there - Default
       run: ls -l TemporaryArtifactStorage/
-
-    - name: Is it all there - Skia
-      run: ls -l TemporaryArtifactStorage/Skia
 
     - name: Is it all there - Windows
       run: ls -l TemporaryArtifactStorage/WindowsUnpackaged

--- a/Apps/PcmApps.sln
+++ b/Apps/PcmApps.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.10.34928.147
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11612.150 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "J2534DotNet", "J2534DotNet\J2534DotNet\J2534DotNet.csproj", "{D99E0DE7-2F06-41E3-B33E-687E1B425A7F}"
 EndProject
@@ -87,8 +87,9 @@ Global
 		{6A27ED5F-BD88-4266-9B63-7DD4A53F591D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A27ED5F-BD88-4266-9B63-7DD4A53F591D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A27ED5F-BD88-4266-9B63-7DD4A53F591D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Debug|Any CPU.Build.0 = Debug|x86
+		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Debug|Any CPU.Deploy.0 = Debug|x86
 		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{285CA6F6-3F85-4B45-976A-18FDFD514D7D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FED6C5BA-2F22-4E9B-8BA8-A419F0903E6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/PcmHacking.UnoUI.Tests.csproj
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/PcmHacking.UnoUI.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +12,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="GitHubActionsTestLogger">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.UITests/PcmHacking.UnoUI.UITests.csproj
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.UITests/PcmHacking.UnoUI.UITests.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.UITests/PcmHacking.UnoUI.UITests.csproj
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.UITests/PcmHacking.UnoUI.UITests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-desktop;net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0;</TargetFrameworks>
+    <TargetFrameworks>net10.0-desktop;net10.0-android;net10.0;</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -49,6 +49,8 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">34.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.1</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.1</TargetPlatformMinVersion>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86</RuntimeIdentifiers>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
   
   <ItemGroup>
@@ -62,6 +64,8 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.26100.0</TargetFrameworks>
+    <Platform Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">x86</Platform>
+    <Platform Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">x64</Platform>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
 
@@ -73,7 +77,7 @@
     <PackageReference Include="System.IO.Ports" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup>  
     <ProjectReference Include="..\..\..\PcmLibraryWindowsApi\PcmLibraryWindowsApi.csproj" />
     <ProjectReference Include="..\..\..\PcmLibrary\PcmLibrary.csproj" />
   </ItemGroup>

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-desktop;net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0;</TargetFrameworks>
+    <TargetFrameworks>net10.0-desktop;net10.0-android;net10.0;</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -49,6 +49,8 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">34.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.1</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.1</TargetPlatformMinVersion>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86</RuntimeIdentifiers>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
   
   <ItemGroup>
@@ -62,6 +64,8 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.26100.0</TargetFrameworks>
+    <Platform Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">x86</Platform>
+    <Platform Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">x64</Platform>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
 
@@ -70,10 +74,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="System.IO.Ports" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\J2534DotNet\J2534DotNet\J2534DotNet.csproj" />
     <ProjectReference Include="..\..\..\PcmLibraryWindowsApi\PcmLibraryWindowsApi.csproj" />
     <ProjectReference Include="..\..\..\PcmLibrary\PcmLibrary.csproj" />
   </ItemGroup>

--- a/Apps/UI/copy-kernels.cmd
+++ b/Apps/UI/copy-kernels.cmd
@@ -1,9 +1,12 @@
+# Someday perhaps Uno will happily build to all platforms under one csproj
 @echo off
 set SOURCE=..\..\Kernels
-set UNO_DEBUG=UnoUI\PcmHacking.UnoUI\bin\debug
+set ARCH32=x86\Debug
+set ARCH64=Debug
+set UNO_PATH=UnoUI\PcmHacking.UnoUI\bin
 echo Source: %SOURCE%
 echo Debug: %DEBUG%
 
 set NET_VERSION=net10.0
-for %%T in ("" android desktop ios maccatalyst windows10.0.26100.0) do copy %SOURCE%\*.bin %UNO_DEBUG%\%NET_VERSION%-%%T
+for %%T in (%ARCH64%\%NET_VERSION%-android %ARCH32%\%NET_VERSION%-windows10.0.26100.0\win-x86) do copy %SOURCE%\*.bin %UNO_PATH%\%%T
 copy %SOURCE%\*.bin WindowsForms\PcmHammer\bin\debug


### PR DESCRIPTION
After some cleanup and verification, this is the minimum setup needed to build for Windows 32-bit.