### PR TITLE
Fix issues with serial traffic.

### DIFF
--- a/Apps/PcmLibrary/Devices/ScanToolDeviceImplementation.cs
+++ b/Apps/PcmLibrary/Devices/ScanToolDeviceImplementation.cs
@@ -143,7 +143,7 @@ namespace PcmHacking
                         break;
 
                     case TimeoutScenario.WriteMemoryBlock:
-                        milliseconds = 140; // 125 works, added some for safety
+                        milliseconds = 250; // Bluetooth needs a touch longer. (MX+ tested)
                         break;
 
                     case TimeoutScenario.SendKernel:

--- a/Apps/PcmLibraryWindowsApi/Ports/StandardPort.cs
+++ b/Apps/PcmLibraryWindowsApi/Ports/StandardPort.cs
@@ -143,10 +143,15 @@ namespace PcmHacking
         /// </summary>
         Task<int> IPort.Receive(byte[] buffer, int offset, int count)
         {
-            return PcmHacking.TimeoutUtilities.TaskWithTimeoutAndFallback(
-                this.port.BaseStream.ReadAsync(buffer, offset, count),
-                TimeSpan.FromMilliseconds(this.port.ReadTimeout),
-                () => 0);
+            try
+            {
+                return TimeoutUtilities.TaskWithTimeoutAndException(
+                    Task.Run(() => this.port.Read(buffer, offset, count)),
+                    TimeSpan.FromMilliseconds(this.port.ReadTimeout));
+            } catch (TimeoutException) 
+            {
+                return Task.FromResult(0);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Found a major issue with the former task handler hanging indefinitely; Refactored.

Testing with Bluetooth OBDLink MX+ showed a slightly longer timeout is needed for writing memory blocks.