### PR TITLE
Refactor AutoSaveDictionary.

### DIFF
--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -101,7 +101,7 @@ public class AutoSaveDictionaryTests
     [Test]
     public void AutoSaveDictionary_PersistsConnectionSettings()
     {
-        CurrentSettings expected = new("Serial", "COM9", "OBDX", true, "CAN0");
+        CurrentSettings expected = new("Serial", "COM9", "OBDX", "JDevice", true, "CAN0");
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -112,9 +112,12 @@ public class AutoSaveDictionaryTests
         rehydrated[key].Should().Be(expected);
     }
 
+    // The only object `AutoSaveDictionary` is programmed to
+    // handle is a `ConnectionSettings` object, verify rejection
+    // of a different object type.
     [Test]
-    public void AutoSaveDictionary_ObjectDiscrepencyTest()
-    {
+    public void AutoSaveDictionary_ObjectDiscrepancyTest()
+    { 
         Message incorrectObject = new([0xFF], 1, 1);
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -73,9 +73,35 @@ public class AutoSaveDictionaryTests
     }
 
     [Test]
+    public void AutoSaveDictionary_PersistsNumberArrayValues()
+    {
+        int[] expected = [1, 2, 3];
+        string key = Guid.NewGuid().ToString();
+        AutoSaveDictionary dictionary = new();
+
+        dictionary[key] = expected;
+
+        AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
+        rehydrated[key].Should().BeEquivalentTo(expected);
+    }
+
+    [Test]
+    public void AutoSaveDictionary_PersistsBoolArrayValues()
+    {
+        bool[] expected = [false, true, false];
+        string key = Guid.NewGuid().ToString();
+        AutoSaveDictionary dictionary = new();
+
+        dictionary[key] = expected;
+
+        AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
+        rehydrated[key].Should().BeEquivalentTo(expected);
+    }
+
+    [Test]
     public void AutoSaveDictionary_PersistsConnectionSettings()
     {
-        CurrentSettings expected = new("Serial", "COM9", "OBDX", "JDevice", true, "CAN0");
+        CurrentSettings expected = new("Serial", "COM9", "OBDX", true, "CAN0");
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 
@@ -84,6 +110,19 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().BeOfType<CurrentSettings>();
         rehydrated[key].Should().Be(expected);
+    }
+
+    [Test]
+    public void AutoSaveDictionary_ObjectDiscrepencyTest()
+    {
+        Message incorrectObject = new([0xFF], 1, 1);
+        string key = Guid.NewGuid().ToString();
+        AutoSaveDictionary dictionary = new();
+
+        dictionary[key] = incorrectObject;
+
+        AutoSaveDictionary? rehydrated = AutoSaveDictionary.Load();
+        Assert.That(rehydrated[key], Is.Null);
     }
 
     private static string GetSettingsFilePath()

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -28,6 +28,7 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().Be(expected);
@@ -41,6 +42,7 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().Be(expected);
@@ -54,6 +56,7 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().Be(expected);
@@ -63,19 +66,14 @@ public class AutoSaveDictionaryTests
     public void AutoSaveDictionary_PersistsStringArrayValues()
     {
         string[] expected = new[] { "Uno", "Dos", "Tres" };
-        string[] expected2 = ["true", "two", "LSx"];
         string key = Guid.NewGuid().ToString();
-        string key2 = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
-        dictionary[key2] = expected2;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().BeEquivalentTo(expected);
-        rehydrated[key].Should().BeOfType<string[]>();
-        rehydrated[key2].Should().BeEquivalentTo(expected2);
-        rehydrated[key2].Should().BeOfType<string[]>();
     }
 
     [Test]
@@ -86,6 +84,7 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().BeEquivalentTo(expected);
@@ -99,6 +98,7 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().BeEquivalentTo(expected);
@@ -107,11 +107,12 @@ public class AutoSaveDictionaryTests
     [Test]
     public void AutoSaveDictionary_PersistsConnectionSettings()
     {
-        CurrentSettings expected = new("Serial", "COM9", "OBDX", "JDevice", true, "CAN0");
+        CurrentSettings expected = new("Serial", "COM9", "OBDX", true, "CAN0");
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key].Should().BeEquivalentTo(expected);
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().BeOfType<CurrentSettings>();
@@ -129,6 +130,7 @@ public class AutoSaveDictionaryTests
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = incorrectObject;
+        Assert.That(dictionary[key], Is.Null);
 
         AutoSaveDictionary? rehydrated = AutoSaveDictionary.Load();
         Assert.That(rehydrated[key], Is.Null);

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -107,7 +107,7 @@ public class AutoSaveDictionaryTests
     [Test]
     public void AutoSaveDictionary_PersistsConnectionSettings()
     {
-        CurrentSettings expected = new("Serial", "COM9", "OBDX", true, "CAN0");
+        CurrentSettings expected = new("Serial", "COM9", "OBDX", "JDevice", true, "CAN0");
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -63,13 +63,19 @@ public class AutoSaveDictionaryTests
     public void AutoSaveDictionary_PersistsStringArrayValues()
     {
         string[] expected = new[] { "Uno", "Dos", "Tres" };
+        string[] expected2 = ["true", "two", "LSx"];
         string key = Guid.NewGuid().ToString();
+        string key2 = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 
         dictionary[key] = expected;
+        dictionary[key2] = expected2;
 
         AutoSaveDictionary rehydrated = AutoSaveDictionary.Load();
         rehydrated[key].Should().BeEquivalentTo(expected);
+        rehydrated[key].Should().BeOfType<string[]>();
+        rehydrated[key2].Should().BeEquivalentTo(expected2);
+        rehydrated[key2].Should().BeOfType<string[]>();
     }
 
     [Test]
@@ -112,9 +118,12 @@ public class AutoSaveDictionaryTests
         rehydrated[key].Should().Be(expected);
     }
 
+    // The only object `AutoSaveDictionary` is programmed to
+    // handle is a `ConnectionSettings` object, verify rejection
+    // of a different object type.
     [Test]
-    public void AutoSaveDictionary_ObjectDiscrepencyTest()
-    {
+    public void AutoSaveDictionary_ObjectDiscrepancyTest()
+    { 
         Message incorrectObject = new([0xFF], 1, 1);
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Models/AutoSaveDictionary.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Models/AutoSaveDictionary.cs
@@ -110,11 +110,17 @@ namespace PcmHacking.UnoUI.Models
                             return element.GetBoolean();
                     }
                 }
-                if(storedValue == null || storedValue is string || storedValue is bool)
+                if(storedValue is string ||
+                   storedValue is bool ||
+                   storedValue is int ||
+                   storedValue is string[] ||
+                   storedValue is bool[] ||
+                   storedValue is int[] ||
+                   storedValue is CurrentSettings) // We should also define all expected object types, to catch any possible mutations.
                 {
                     return storedValue;
                 }
-                return null; // At this point, if it's not a simple string or boolean type, we have a problem...
+                return null; // At this point, if it's not a simple string or boolean type, return null.
             }
             set
             {

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Models/AutoSaveDictionary.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Models/AutoSaveDictionary.cs
@@ -13,7 +13,16 @@ namespace PcmHacking.UnoUI.Models
     public class AutoSaveDictionary : IPropertySet
     {
         private readonly Dictionary<string, object?> _storageContainer;
-        private static readonly JsonSerializerOptions _serializerOptions = new() { WriteIndented = true, UnmappedMemberHandling = System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow};
+
+        // Setting `UnmappedMemberHandling` to `Disallow` will cause
+        // the (De)Serializer to reject and throw an exception if an
+        // attempt to load an incorrect object type occurs. Used in
+        // the `TryDeserialize` method, as well as load and save.
+        private static readonly JsonSerializerOptions _serializerOptions = new() 
+        {
+            WriteIndented = true, 
+            UnmappedMemberHandling = System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow
+        };
 
         public AutoSaveDictionary()
         {
@@ -80,7 +89,7 @@ namespace PcmHacking.UnoUI.Models
                             var array = element.EnumerateArray().ToArray();
                             if (array.Length > 0)
                             {
-                                switch (array[0].ValueKind)
+                                switch (array[0].ValueKind) // This of course has potential for failure, 
                                 {
                                     case JsonValueKind.String:
                                         return array.Select(x => x.ToString()).ToArray();

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Models/AutoSaveDictionary.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Models/AutoSaveDictionary.cs
@@ -5,29 +5,15 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
+using Uno.Extensions.Specialized;
 using Windows.Foundation.Collections;
 
 namespace PcmHacking.UnoUI.Models
 {
     public class AutoSaveDictionary : IPropertySet
     {
-        private class TypeAndValue
-        {
-            public string? Type { get; set; }
-            public JsonElement? Value { get; set; }
-
-            public TypeAndValue()
-            {
-            }
-
-            public TypeAndValue(string? type, JsonElement? value)
-            {
-                Type = type;
-                Value = value;
-            }
-        }
-
         private readonly Dictionary<string, object?> _storageContainer;
+        private static readonly JsonSerializerOptions _serializerOptions = new() { WriteIndented = true, UnmappedMemberHandling = System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow};
 
         public AutoSaveDictionary()
         {
@@ -39,7 +25,7 @@ namespace PcmHacking.UnoUI.Models
             AutoSaveDictionary dictionary = new();
             try
             {
-                string filePath = AutoSaveDictionary.getFilePath();
+                string filePath = getFilePath();
                 if (!File.Exists(filePath))
                 {
                     using FileStream stream = File.Create(filePath);
@@ -52,17 +38,12 @@ namespace PcmHacking.UnoUI.Models
                     return dictionary;
                 }
 
-                Dictionary<string, JsonElement>? persistedEntries = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(contents);
+                Dictionary<string, object>? persistedEntries = JsonSerializer.Deserialize<Dictionary<string, object>>(contents, _serializerOptions);
                 if (persistedEntries is null)
                 {
                     return dictionary;
                 }
-
-                foreach (KeyValuePair<string, JsonElement> entry in persistedEntries)
-                {
-                    dictionary._storageContainer[entry.Key] = DeserializePersistedEntry(entry.Value);
-                }
-
+                dictionary.AddRange(persistedEntries);
                 return dictionary;
             }
             catch
@@ -80,14 +61,70 @@ namespace PcmHacking.UnoUI.Models
                     _storageContainer[key] = null;
                     return null;
                 }
-
-                return storedValue;
+                if (storedValue is JsonElement)
+                {
+                    JsonElement element = (JsonElement)storedValue;
+                    switch (element.ValueKind)
+                    {
+                        case JsonValueKind.Undefined:
+                        case JsonValueKind.Object: // Storing class objects in a JsonElement is possible, but will need manual testing to pull it back out.
+                            string json = element.ToString();
+                            if (TryDeserialize(json, out CurrentSettings settings))
+                            {
+                                return settings;
+                            }
+                            break;
+                        case JsonValueKind.Null:
+                            return null; // These cases should not happen.
+                        case JsonValueKind.Array: // Arrays will need some manual handling.
+                            var array = element.EnumerateArray().ToArray();
+                            if (array.Length > 0)
+                            {
+                                switch (array[0].ValueKind)
+                                {
+                                    case JsonValueKind.String:
+                                        return array.Select(x => x.ToString()).ToArray();
+                                    case JsonValueKind.Number:
+                                        return array.Select(x => x.GetInt32()).ToArray();
+                                    case JsonValueKind.True:
+                                    case JsonValueKind.False:
+                                        return array.Select(x => x.GetBoolean()).ToArray();
+                                }
+                            }
+                                break;
+                        case JsonValueKind.String:
+                            return element.GetString();
+                        case JsonValueKind.Number:
+                            return element.GetInt32();
+                        case JsonValueKind.True:
+                        case JsonValueKind.False:
+                            return element.GetBoolean();
+                    }
+                }
+                if(storedValue == null || storedValue is string || storedValue is bool)
+                {
+                    return storedValue;
+                }
+                return null; // At this point, if it's not a simple string or boolean type, we have a problem...
             }
             set
             {
                 _storageContainer[key] = value;
                 Persist();
             }
+        }
+
+        private bool TryDeserialize<T>(string jsonString, out T outputObject)
+        {
+            try
+            {
+                outputObject = JsonSerializer.Deserialize<T>(jsonString, _serializerOptions);
+            } catch (Exception)
+            {
+                outputObject = default(T);
+                return false;
+            }
+            return true;
         }
 
         public ICollection<string> Keys => _storageContainer.Keys;
@@ -169,34 +206,12 @@ namespace PcmHacking.UnoUI.Models
             return GetEnumerator();
         }
 
-        private static TypeAndValue CreateTypeAnnotatedValue(object? value)
-        {
-            if (value is TypeAndValue wrapper)
-            {
-                return wrapper;
-            }
-
-            Type actualType = value?.GetType() ?? typeof(object);
-            JsonElement serializedValue = value is JsonElement jsonElement
-                ? jsonElement
-                : JsonSerializer.SerializeToElement(value, actualType);
-
-            return new TypeAndValue(GetTypeIdentifier(actualType), serializedValue);
-        }
-
         private void Persist()
         {
             try
             {
                 string filePath = AutoSaveDictionary.getFilePath();
-                Dictionary<string, TypeAndValue> persistedEntries = new(_storageContainer.Count);
-
-                foreach (KeyValuePair<string, object?> entry in _storageContainer)
-                {
-                    persistedEntries[entry.Key] = CreateTypeAnnotatedValue(entry.Value);
-                }
-
-                string contents = JsonSerializer.Serialize(persistedEntries);
+                string contents = JsonSerializer.Serialize(_storageContainer, _serializerOptions);
                 if (!string.IsNullOrEmpty(contents))
                 {
                     File.WriteAllText(filePath, contents);
@@ -205,85 +220,6 @@ namespace PcmHacking.UnoUI.Models
             catch
             {
             }
-        }
-
-        private static object? DeserializePersistedEntry(JsonElement element)
-        {
-            if (TryConvertJsonElementToWrapper(element, out TypeAndValue? wrapper))
-            {
-                return DeserializeWrapper(wrapper);
-            }
-
-            try
-            {
-                return element.Deserialize<object?>();
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        private static bool TryConvertJsonElementToWrapper(JsonElement element, [NotNullWhen(true)] out TypeAndValue? typeAndValue)
-        {
-            if (element.ValueKind != JsonValueKind.Object)
-            {
-                typeAndValue = null;
-                return false;
-            }
-
-            string? typeName = null;
-            JsonElement? valueElement = null;
-
-            if (element.TryGetProperty(nameof(TypeAndValue.Type), out JsonElement typeProperty))
-            {
-                typeName = typeProperty.GetString();
-            }
-
-            if (element.TryGetProperty(nameof(TypeAndValue.Value), out JsonElement valueProperty))
-            {
-                valueElement = valueProperty;
-            }
-
-            if (typeName is null && valueElement is null)
-            {
-                typeAndValue = null;
-                return false;
-            }
-
-            typeAndValue = new TypeAndValue(typeName, valueElement);
-            return true;
-        }
-
-        private static object? DeserializeWrapper(TypeAndValue wrapper)
-        {
-            if (wrapper.Value is null)
-            {
-                return null;
-            }
-
-            Type? targetType = null;
-
-            if (!string.IsNullOrWhiteSpace(wrapper.Type))
-            {
-                targetType = Type.GetType(wrapper.Type);
-            }
-
-            targetType ??= typeof(object);
-
-            try
-            {
-                return JsonSerializer.Deserialize(wrapper.Value.Value, targetType);
-            }
-            catch
-            {
-                return wrapper.Value.Value.Deserialize<object?>();
-            }
-        }
-
-        private static string GetTypeIdentifier(Type type)
-        {
-            return type.AssemblyQualifiedName ?? type.FullName ?? type.Name;
         }
 
         private static string getFilePath()


### PR DESCRIPTION
Even with the additional type safety, an exception occurs trying to enter the writer page with the runtime trying to convert a JsonElement to a boolean. The contained revision removes additional type safety, and follows the assumption that the contained data will only ever be a basic type or a JsonElement.

Added extra security for local memory objects, as they will be passed around when first added as their defined type until reloading from disk occurs. Tests adjusted to validate.

I have added a couple tests and support for additional future storage possibilities. All tests pass.