### PR TITLE
Net10 uno - Fix connection issues related to J devices.

### DIFF
--- a/Apps/J2534DotNet/J2534DotNet/IJ2534.cs
+++ b/Apps/J2534DotNet/J2534DotNet/IJ2534.cs
@@ -30,7 +30,7 @@ namespace J2534DotNet
 {
     public interface IJ2534
     {
-        bool LoadLibrary(J2534Device device);
+        bool LoadLibrary(J2534DeviceInfo device);
         bool FreeLibrary();
         J2534Err Open(ref int deviceId);
         J2534Err Close(int deviceId);

--- a/Apps/J2534DotNet/J2534DotNet/J2534.cs
+++ b/Apps/J2534DotNet/J2534DotNet/J2534.cs
@@ -32,10 +32,10 @@ namespace J2534DotNet
 {
     public class J2534 : IJ2534
     {
-        private J2534Device m_device;
+        private J2534DeviceInfo m_device;
         private J2534DllWrapper m_wrapper;
 
-        public bool LoadLibrary(J2534Device device)
+        public bool LoadLibrary(J2534DeviceInfo device)
         {
             m_device = device;
             m_wrapper = new J2534DllWrapper();

--- a/Apps/J2534DotNet/J2534DotNet/J2534.cs
+++ b/Apps/J2534DotNet/J2534DotNet/J2534.cs
@@ -44,11 +44,19 @@ namespace J2534DotNet
 
         public bool FreeLibrary()
         {
+            if (m_wrapper == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             return m_wrapper.FreeLibrary();
         }
 
         public J2534Err Open(ref int deviceId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr DeviceNamePtr = IntPtr.Zero;
             IntPtr DeviceIDPtr = Marshal.AllocHGlobal(4);
             Marshal.WriteInt32(DeviceIDPtr, deviceId);
@@ -64,36 +72,59 @@ namespace J2534DotNet
 
         public J2534Err Close(int deviceId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
+
             return (J2534Err)m_wrapper.Close(deviceId);
         }
 
         public J2534Err Connect(int deviceId, ProtocolID protocolId, ConnectFlag flags, BaudRate baudRate, ref int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
+
             return (J2534Err)m_wrapper.Connect(deviceId, (int)protocolId, (int)flags, (int)baudRate, ref channelId);
         }
 
         public J2534Err Connect(int deviceId, ProtocolID protocolId, ConnectFlag flags, int baudRate, ref int channelId)
         {
-            return (J2534Err)m_wrapper.Connect(deviceId, (int)protocolId, (int)flags, baudRate, ref channelId);
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
+
+            return (J2534Err)m_wrapper?.Connect(deviceId, (int)protocolId, (int)flags, baudRate, ref channelId);
         }
 
         public J2534Err Disconnect(int channelId)
         {
-            return (J2534Err)m_wrapper.Disconnect(channelId);
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
+            return (J2534Err)m_wrapper?.Disconnect(channelId);
         }
 
         public J2534Err ReadMsgs(int channelId, ref List<PassThruMsg> msgs, ref int numMsgs, int timeout)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr pMsg = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(UnsafePassThruMsg)));
             IntPtr pNextMsg = IntPtr.Zero;
             IntPtr[] pMsgs = new IntPtr[50];
             J2534Err returnValue = (J2534Err)m_wrapper.ReadMsgs(channelId, pMsg, ref numMsgs, timeout);
-            
+
             if (returnValue == J2534Err.STATUS_NOERROR)
             {
                 for (int i = 0; i < numMsgs; i++)
                 {
-                    pNextMsg = (IntPtr)(Marshal.SizeOf(typeof(UnsafePassThruMsg))*i + (int)pMsg);
+                    pNextMsg = (IntPtr)(Marshal.SizeOf(typeof(UnsafePassThruMsg)) * i + (int)pMsg);
                     UnsafePassThruMsg uMsg = (UnsafePassThruMsg)Marshal.PtrToStructure(pMsg, typeof(UnsafePassThruMsg));
                     msgs.Add(ConvertPassThruMsg(uMsg));
                 }
@@ -106,6 +137,11 @@ namespace J2534DotNet
 
         public J2534Err WriteMsgs(int channelId, ref PassThruMsg msg, ref int numMsgs, int timeout)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
+
             UnsafePassThruMsg uMsg = ConvertPassThruMsg(msg);
             // TODO: change function to accept a list? of PassThruMsg
             return (J2534Err)m_wrapper.WriteMsgs(channelId, ref uMsg, ref numMsgs, timeout);
@@ -113,12 +149,20 @@ namespace J2534DotNet
 
         public J2534Err StartPeriodicMsg(int channelId, ref PassThruMsg msg, ref int msgId, int timeInterval)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             UnsafePassThruMsg uMsg = ConvertPassThruMsg(msg);
             return (J2534Err)m_wrapper.StartPeriodicMsg(channelId, ref uMsg, ref msgId, timeInterval);
         }
 
         public J2534Err StopPeriodicMsg(int channelId, int msgId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             return (J2534Err)m_wrapper.StopPeriodicMsg(channelId, msgId);
         }
 
@@ -132,16 +176,20 @@ namespace J2534DotNet
             ref int filterId
         )
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             UnsafePassThruMsg uMaskMsg = ConvertPassThruMsg(maskMsg);
             UnsafePassThruMsg uPatternMsg = ConvertPassThruMsg(patternMsg);
             UnsafePassThruMsg uFlowControlMsg = ConvertPassThruMsg(flowControlMsg);
             return (J2534Err)m_wrapper.StartMsgFilter
                     (
-                        channelid, 
+                        channelid,
                         (int)filterType,
                         ref uMaskMsg,
                         ref uPatternMsg,
-                        ref uFlowControlMsg, 
+                        ref uFlowControlMsg,
                         ref filterId
                     );
         }
@@ -155,6 +203,10 @@ namespace J2534DotNet
             ref int filterId
         )
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             int nada = 0;
             UnsafePassThruMsg uMaskMsg = ConvertPassThruMsg(maskMsg);
             UnsafePassThruMsg uPatternMsg = ConvertPassThruMsg(patternMsg);
@@ -171,16 +223,28 @@ namespace J2534DotNet
 
         public J2534Err StopMsgFilter(int channelId, int filterId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             return (J2534Err)m_wrapper.StopMsgFilter(channelId, filterId);
         }
 
         public J2534Err SetProgrammingVoltage(int deviceId, PinNumber pinNumber, int voltage)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             return (J2534Err)m_wrapper.SetProgrammingVoltage(deviceId, (int)pinNumber, voltage);
         }
 
         public J2534Err ReadVersion(int deviceId, ref string firmwareVersion, ref string dllVersion, ref string apiVersion)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr pFirmwareVersion = Marshal.AllocHGlobal(120);
             IntPtr pDllVersion = Marshal.AllocHGlobal(120);
             IntPtr pApiVersion = Marshal.AllocHGlobal(120);
@@ -201,6 +265,10 @@ namespace J2534DotNet
 
         public J2534Err GetLastError(ref string errorDescription)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr pErrorDescription = Marshal.AllocHGlobal(120);
             J2534Err returnValue = (J2534Err)m_wrapper.GetLastError(pErrorDescription);
             if (returnValue == J2534Err.STATUS_NOERROR)
@@ -215,6 +283,10 @@ namespace J2534DotNet
 
         public J2534Err GetConfig(int channelId, ref List<SConfig> config)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -223,6 +295,10 @@ namespace J2534DotNet
 
         public J2534Err SetConfig(int channelId, ref List<SConfig> config)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -231,6 +307,10 @@ namespace J2534DotNet
 
         public J2534Err ReadBatteryVoltage(int deviceId, ref int voltage)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = Marshal.AllocHGlobal(8);
 
@@ -247,6 +327,10 @@ namespace J2534DotNet
 
         public J2534Err FiveBaudInit(int channelId, byte targetAddress, ref byte keyword1, ref byte keyword2)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             J2534Err returnValue;
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
@@ -271,6 +355,10 @@ namespace J2534DotNet
 
         public J2534Err FastInit(int channelId, PassThruMsg txMsg, ref PassThruMsg rxMsg)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
             UnsafePassThruMsg uTxMsg = ConvertPassThruMsg(txMsg);
@@ -291,6 +379,10 @@ namespace J2534DotNet
 
         public J2534Err ClearTxBuffer(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -299,6 +391,10 @@ namespace J2534DotNet
 
         public J2534Err ClearRxBuffer(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -307,6 +403,10 @@ namespace J2534DotNet
 
         public J2534Err ClearPeriodicMsgs(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -315,6 +415,10 @@ namespace J2534DotNet
 
         public J2534Err ClearMsgFilters(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -323,6 +427,10 @@ namespace J2534DotNet
 
         public J2534Err ClearFunctMsgLookupTable(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
 
@@ -331,6 +439,10 @@ namespace J2534DotNet
 
         public J2534Err AddToFunctMsgLookupTable(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
             // TODO: fix this
@@ -339,6 +451,10 @@ namespace J2534DotNet
 
         public J2534Err DeleteFromFunctMsgLookupTable(int channelId)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             IntPtr input = IntPtr.Zero;
             IntPtr output = IntPtr.Zero;
             // TODO: fix this
@@ -347,6 +463,10 @@ namespace J2534DotNet
 
         private UnsafePassThruMsg ConvertPassThruMsg(PassThruMsg msg)
         {
+            if (m_wrapper == null || m_device == null)
+            {
+                throw new NullReferenceException("J2534 wrapper object is null.");
+            }
             UnsafePassThruMsg uMsg = new UnsafePassThruMsg();
 
             uMsg.ProtocolID = (int)msg.ProtocolID;

--- a/Apps/J2534DotNet/J2534DotNet/J2534Detect.cs
+++ b/Apps/J2534DotNet/J2534DotNet/J2534Detect.cs
@@ -34,9 +34,9 @@ namespace J2534DotNet
         private const string PASSTHRU_REGISTRY_PATH = "Software\\PassThruSupport.04.04";
         private const string PASSTHRU_REGISTRY_PATH_6432 = "Software\\Wow6432Node\\PassThruSupport.04.04";
 
-        static public List<J2534Device> ListDevices()
+        static public List<J2534DeviceInfo> ListDevices()
         {
-            List<J2534Device> j2534Devices = new List<J2534Device>();
+            List<J2534DeviceInfo> j2534Devices = new List<J2534DeviceInfo>();
             RegistryKey myKey = Registry.LocalMachine.OpenSubKey(PASSTHRU_REGISTRY_PATH, false);
             if (myKey == null)
             {
@@ -47,7 +47,7 @@ namespace J2534DotNet
             string[] devices = myKey.GetSubKeyNames();
             foreach (string device in devices)
             {
-                J2534Device tempDevice = new J2534Device();
+                J2534DeviceInfo tempDevice = new J2534DeviceInfo();
                 RegistryKey deviceKey = myKey.OpenSubKey(device);
                 if(deviceKey == null)
                     continue;

--- a/Apps/J2534DotNet/J2534DotNet/J2534DeviceInfo.cs
+++ b/Apps/J2534DotNet/J2534DotNet/J2534DeviceInfo.cs
@@ -26,7 +26,7 @@
 #endregion License
 namespace J2534DotNet
 {
-    public class J2534Device
+    public class J2534DeviceInfo
     {
         public string Vendor { get; set; }
         public string Name { get; set; }

--- a/Apps/J2534DotNet/J2534DotNet/J2534DotNet.csproj
+++ b/Apps/J2534DotNet/J2534DotNet/J2534DotNet.csproj
@@ -60,7 +60,7 @@
     <Compile Include="IJ2534.cs" />
     <Compile Include="J2534.cs" />
     <Compile Include="J2534Defs.cs" />
-    <Compile Include="J2534Device.cs" />
+    <Compile Include="J2534DeviceInfo.cs" />
     <Compile Include="J2534DllWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Apps/PcmLibraryWindowsApi/Devices/DeviceFactory.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/DeviceFactory.cs
@@ -27,14 +27,14 @@ namespace PcmHacking
             }
         }
 
-        public static Device CreateDevice(ILogger logger, string deviceCategory, string serialPort, string serialPortDeviceType, string j2534DeviceType)
+        public static Device CreateDevice(ILogger logger, string deviceCategory, string serialPort, string serialPortDeviceType)
         {
             switch (deviceCategory)
             {
                 case DeviceConfiguration.Constants.DeviceCategorySerial:
                     return CreateSerialDevice(serialPort, serialPortDeviceType, logger);
                 case DeviceConfiguration.Constants.DeviceCategoryJ2534:
-                    return CreateJ2534Device(j2534DeviceType, logger);
+                    return CreateJ2534Device(serialPortDeviceType, logger);
                 default:
                     return null;
             }

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
@@ -83,7 +83,14 @@ namespace PcmHacking
         // it just wraps a private method that does the real work and returns a bool.
         public override async Task<bool> Initialize()
         {
+            try
+            {
             return await Task.FromResult(this.InitializeInternal());
+        }
+            catch (NullReferenceException)
+            {
+                return false;
+            }
         }
 
         // This returns 'bool' for the sake of readability. That bool needs to be

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
@@ -367,13 +367,15 @@ namespace PcmHacking
         /// </summary>
         private Response<J2534Err> DisconnectTool()
         {
-            if (IsJ2534Open == true) {
+            if (IsJ2534Open == true)
+            {
                 OBDError = J2534Port.Functions.Close((int)DeviceID);
                 if (OBDError != J2534Err.STATUS_NOERROR)
                 {
                     // Big problems, do something here
                 }
                 IsJ2534Open = false;
+                CloseLibrary();
                 }
             return Response.Create(ResponseStatus.Success, OBDError);
         }

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
@@ -51,10 +51,10 @@ namespace PcmHacking
         struct J2534_Struct
         {
             public J2534 Functions;
-            public J2534DotNet.J2534Device LoadedDevice;
+            public J2534DeviceInfo LoadedDevice;
         }
 
-        public J2534Device(J2534DotNet.J2534Device jport, ILogger logger) : base(logger)
+        public J2534Device(J2534DeviceInfo jport, ILogger logger) : base(logger)
         {
             J2534Port = new J2534_Struct();
             J2534Port.Functions = new J2534();
@@ -304,7 +304,7 @@ namespace PcmHacking
         /// <summary>
         /// Load in dll
         /// </summary>
-        private Response<bool> LoadLibrary(J2534DotNet.J2534Device TempDevice)
+        private Response<bool> LoadLibrary(J2534DeviceInfo TempDevice)
         {
             ToolName = TempDevice.Name;
             J2534Port.LoadedDevice = TempDevice;

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534DeviceFinder.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534DeviceFinder.cs
@@ -18,8 +18,8 @@ namespace PcmHacking
             List<J2534DeviceInfo> installedDLLs = new List<J2534DeviceInfo>();
             try
             {
-                installedDLLs = J2534DotNet.J2534Detect.ListDevices();
-                return installedDLLs;
+                installedDLLs = J2534Detect.ListDevices();
+                return [.. installedDLLs.Where(x => !string.IsNullOrWhiteSpace(x.Name))];
             }
             catch (Exception exception)
             {

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534DeviceFinder.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534DeviceFinder.cs
@@ -13,9 +13,9 @@ namespace PcmHacking
         /// <summary>
         /// Find all installed J2534 DLLs
         /// </summary>
-        public static List<J2534DotNet.J2534Device> FindInstalledJ2534DLLs(ILogger logger)
+        public static List<J2534DeviceInfo> FindInstalledJ2534DLLs(ILogger logger)
         {
-            List<J2534DotNet.J2534Device> installedDLLs = new List<J2534DotNet.J2534Device>();
+            List<J2534DeviceInfo> installedDLLs = new List<J2534DeviceInfo>();
             try
             {
                 installedDLLs = J2534DotNet.J2534Detect.ListDevices();

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI.Tests/AutoSaveDictionaryTests.cs
@@ -75,7 +75,7 @@ public class AutoSaveDictionaryTests
     [Test]
     public void AutoSaveDictionary_PersistsConnectionSettings()
     {
-        CurrentSettings expected = new("Serial", "COM9", "OBDX", "JDevice", true, "CAN0");
+        CurrentSettings expected = new("Serial", "COM9", "OBDX", true, "CAN0");
         string key = Guid.NewGuid().ToString();
         AutoSaveDictionary dictionary = new();
 

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/SettingsModel.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/SettingsModel.cs
@@ -12,9 +12,8 @@ namespace PcmHacking.UnoUI.Presentation;
 
 public record CurrentSettings(
     string DeviceCategory, 
-    string Obd2SerialPortName, 
-    string Obd2SerialDeviceName, 
-    string J2534DeviceName, 
+    string PortName, 
+    string DeviceName, 
     bool CanEnabled, 
     string CanPort);
 
@@ -109,11 +108,17 @@ public partial record SettingsModel
 
     private async ValueTask ConnectionSettingsChanged<T>(T newValue, CancellationToken ct)
     {
+        bool useSerial = await this.UseSerialDevice.Value();
+        if (!useSerial)
+        {
+            string? selectedJDevice = await SelectedJDevice.Value();
+            await SelectedDeviceType.SetAsync(selectedJDevice);
+            await SelectedObd2Port.SetAsync("J2534");
+        }
         CurrentSettings currentSettings = new CurrentSettings(
-            await this.UseSerialDevice.Value() ? "Serial" : "J2534",
+            useSerial ? "Serial" : "J2534",
             await this.SelectedObd2Port.Value() ?? "",
-            await this.SelectedObd2SerialDeviceType.Value() ?? "",
-            "", // TODO: J2534 device name
+            await this.SelectedDeviceType.Value() ?? "",
             await this.UseCanDevice.Value(),
             await this.SelectedCanPort.Value() ?? "");
 

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/ConnectionService.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/ConnectionService.cs
@@ -254,9 +254,9 @@ public class ConnectionService : IConnectionService
         Device newDevice = DeviceFactory.CreateDevice(
             this.logger,
             settings.DeviceCategory,
-            settings.Obd2SerialPortName,
-            settings.Obd2SerialDeviceName,
-            settings.J2534DeviceName);
+            settings.PortName,
+            settings.DeviceName);
+        if (newDevice == null || !await newDevice.Initialize())
         if (newDevice == null)
         {
             return (null, null);

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/SettingsService.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/SettingsService.cs
@@ -127,6 +127,9 @@ public class SettingsService : ISettingsService
     {
     }
 
+    private bool IsSerialDevice() => (string)_settingsListInterface[Obd2DeviceCategoryKey] == "Serial";
+
+    public string GetActiveDeviceName() => IsSerialDevice() ? GetObd2SerialDeviceName() : GetJ2534DeviceName();
 
     public string GetObd2DeviceCategory()
     {
@@ -162,19 +165,18 @@ public class SettingsService : ISettingsService
     {
         return new CurrentSettings(
             _settingsListInterface[Obd2DeviceCategoryKey] as string ?? string.Empty,
-            _settingsListInterface[Obd2SerialPortNameKey] as string ?? string.Empty,
-            _settingsListInterface[Obd2SerialDeviceNameKey] as string ?? string.Empty,
-            _settingsListInterface[J2534DeviceNameKey] as string ?? string.Empty,
+            IsSerialDevice() ? ((string)_settingsListInterface[Obd2SerialPortNameKey]) : "J2534" ?? string.Empty,
+            IsSerialDevice() ? ((string)_settingsListInterface[Obd2SerialDeviceNameKey]) : ((string)_settingsListInterface[J2534DeviceNameKey]) ?? string.Empty,
             _settingsListInterface[CanEnabledKey] as string == "true",
             _settingsListInterface[CanSerialPortNameKey] as string ?? string.Empty);
     }
 
     public void SaveConnectionSettings(CurrentSettings settings)
     {
-        _settingsListInterface[J2534DeviceNameKey] = settings.J2534DeviceName;
         _settingsListInterface[Obd2DeviceCategoryKey] = settings.DeviceCategory;
-        _settingsListInterface[Obd2SerialPortNameKey] = settings.Obd2SerialPortName;
-        _settingsListInterface[Obd2SerialDeviceNameKey] = settings.Obd2SerialDeviceName;
+        _settingsListInterface[Obd2SerialPortNameKey] = IsSerialDevice() ? settings.PortName : (string)_settingsListInterface[Obd2SerialPortNameKey]; // Don't overwrite with "J25
+        _settingsListInterface[Obd2SerialDeviceNameKey] = IsSerialDevice() ? settings.DeviceName : (string)_settingsListInterface[Obd2SerialDeviceNameKey];
+        _settingsListInterface[J2534DeviceNameKey] = !IsSerialDevice() ? settings.DeviceName : (string)_settingsListInterface[J2534DeviceNameKey];
         _settingsListInterface[CanEnabledKey] = settings.CanEnabled ? "true" : "false";
         _settingsListInterface[CanSerialPortNameKey] = settings.CanPort;
     }

--- a/Apps/UI/WindowsForms/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
+++ b/Apps/UI/WindowsForms/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
@@ -183,7 +183,7 @@ namespace PcmHacking
             this.j2534DeviceList.Items.Add(prompt);
             this.j2534DeviceList.SelectedIndex = 0;
 
-            foreach(J2534DotNet.J2534Device device in J2534DeviceFinder.FindInstalledJ2534DLLs(this.logger))
+            foreach(J2534DeviceInfo device in J2534DeviceFinder.FindInstalledJ2534DLLs(this.logger))
             {
                 this.j2534DeviceList.Items.Add(device);
             }


### PR DESCRIPTION
Throwing the following changes as a separate PR, as they are more related to connection issues:

* It makes sense that in passing a device catergory and a device name, logic should be able to route that to the proper initializer. Modifications to SettingsService to load and save from the correct "slot" based on selected catergory. Cleaned up related code and tested.

* Renaming J2534DotNet's J2534Device to J2534DeviceInfo. This better represents it's usage, and greatly helps with clarity between projects. Updates all projects to match.

* Add null checks to J2534 class to prevent connect loop aborts.

* Issue found after device connection was lost due to libarary loaded but not hooked. Unloading library on disposal fixes this issue.

* In my driver list seemingly exists an entry with a null/empty name. This caused havoc with the UI, always defaulting to that selection as active. Filter out any empty entries.
TODO? Perhaps we could rename the device to "Unnamed device" and add it, in the event it's some glitch with a driver. Your call good sir.