### PR TITLE
fix crash on file picker save

### DIFF
--- a/Apps/PcmLibrary/ReadManager.cs
+++ b/Apps/PcmLibrary/ReadManager.cs
@@ -70,13 +70,8 @@ namespace PcmHacking
                     this.logger.AddUserMessage("Unable to save file: " + exception.Message);
                     this.logger.AddDebugMessage(exception.ToString());
 
-                    try
-                    {
-                        await this.invoke(async () =>
-                            path = await this.promptForFilePath()
-                        );
-                    }
-                    catch
+                    await this.invoke(async () => path = await this.promptForFilePath());
+                    if (path == null)
                     {
                         this.logger.AddUserMessage("Save canceled.");
 

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
@@ -1188,13 +1188,9 @@ namespace PcmHacking
 
                     // Get the path to save the image to.
                     string path = "";
-                    try
-                    {
-                        await this.InvokeWrapper(async () =>
-                            path = await this.PromptForFileSavePath()
-                        );
-                    }
-                    catch
+                    await this.InvokeWrapper(async () => path = await this.PromptForFileSavePath());
+
+                    if (path == null)
                     {
                         this.AddUserMessage("Read canceled.");
                         return;
@@ -1241,7 +1237,7 @@ namespace PcmHacking
 
             if (path == null)
             {
-                return null;
+                return Task.FromResult<string>(null);
             }
 
             this.AddUserMessage("Will save to " + path);
@@ -1250,7 +1246,7 @@ namespace PcmHacking
             DialogResult dialogResult = dialogBox.ShowDialog(this);
             if (dialogResult == DialogResult.Cancel)
             {
-                return null;
+                return Task.FromResult<string>(null);
             }
 
             return Task.FromResult(path);


### PR DESCRIPTION
just a small fix for exception handling that was needed due to a null path return when the users cancels the read dialog.