### PR TITLE
Antus/readandwritedialogs

### DIFF
--- a/Apps/PcmLibrary/CKernelReader.cs
+++ b/Apps/PcmLibrary/CKernelReader.cs
@@ -233,12 +233,19 @@ namespace PcmHacking
 
                     logger.StatusUpdateReset();
 
-                    if (await verifier.CompareRanges(
+                    CrcVerificationResult verificationResult = await verifier.CompareRanges(
                         image,
                         BlockType.All,
-                        cancellationToken))
+                        cancellationToken);
+
+                    if (verificationResult == CrcVerificationResult.Verified)
                     {
                         logger.AddUserMessage("The contents of the file match the contents of the PCM.");
+                    }
+                    else if (verificationResult == CrcVerificationResult.Timeout)
+                    {
+                        MemoryStream unverifiedStream = new MemoryStream(image);
+                        return new Response<Stream>(ResponseStatus.Unverified, unverifiedStream);
                     }
                     else
                     {

--- a/Apps/PcmLibrary/CKernelVerifier.cs
+++ b/Apps/PcmLibrary/CKernelVerifier.cs
@@ -8,6 +8,14 @@ using System.Threading.Tasks;
 
 namespace PcmHacking
 {
+    public enum CrcVerificationResult
+    {
+        Verified,
+        Mismatch,
+        Timeout,
+        Cancelled,
+    }
+
     public class CKernelVerifier
     {
         private readonly byte[] image;
@@ -51,13 +59,14 @@ namespace PcmHacking
         /// <summary>
         /// Compare CRCs from the file to CRCs from the PCM.
         /// </summary>
-        public async Task<bool> CompareRanges(byte[] image, BlockType blockTypes, CancellationToken cancellationToken)
+        public async Task<CrcVerificationResult> CompareRanges(byte[] image, BlockType blockTypes, CancellationToken cancellationToken)
         {
             // This only takes a fraction of a second.
             logger.AddUserMessage("Calculating CRCs from file.");
             this.GetCrcFromImage();
 
-            bool successForAllRanges = true;
+            bool anyTimeout = false;
+            bool anyMismatch = false;
 
             await this.vehicle.SendToolPresentNotification();
             await this.vehicle.SetDeviceTimeout(TimeoutScenario.ReadCrc);
@@ -68,25 +77,11 @@ namespace PcmHacking
             foreach (MemoryRange range in this.ranges)
             {
                 string formatString = "{0:X6}-{1:X6}\t{2:X8}\t{3:X8}\t{4}\t{5}";
-
-                string range_type = "General";
-
-                if (pcmInfo.IsSupportedWriteBySegment)
-                {
-                    range_type = range.Type.ToString();
-                }
+                string range_type = pcmInfo.IsSupportedWriteBySegment ? range.Type.ToString() : "General";
 
                 if (((range.Type & blockTypes) == 0) || (range.Address >= this.pcmInfo.ImageSize))
                 {
-                    this.logger.AddUserMessage(
-                    string.Format(
-                        formatString,
-                        range.Address,
-                        range.Address + (range.Size - 1),
-                        "not needed",
-                        "not needed",
-                        "n/a",
-                        range_type));
+                    this.logger.AddUserMessage(string.Format(formatString, range.Address, range.Address + (range.Size - 1), "not needed", "not needed", "n/a", range_type));
                     continue;
                 }
 
@@ -94,23 +89,22 @@ namespace PcmHacking
                 this.vehicle.ClearDeviceMessageQueue();
                 logger.StatusUpdateActivity($"Processing CRC for range {range.Address:X6}-{range.Address + (range.Size - 1):X6}");
 
-                // For C Kernels each poll of the pcm causes it to CRC 16kb of segment data.
-                // When the segment sum is available it is returned.
-                int maxAttempts = 50; // Logged highs of 38 on 1m P12, the rest are a good deal lower.
-                int retryDelay = 50; // used for polling speed
+                // For C Kernels each poll of the PCM causes it to CRC 16kb of segment data.
+                // When the segment sum is available it is returned. Logged highs of 38 polls on a 1m P12.
+                int retryDelay = 50;
                 bool success = false;
+                int consecutiveTimeouts = 0;
                 UInt32 crc = 0;
 
                 Message query = this.protocol.CreateCrcQuery(range.Address, range.Size);
-                for (int segment = 0; segment < maxAttempts; segment++)
+                while (true)
                 {
-                    logger.StatusUpdateActivity($"Processing CRC for range {range.Address:X6}-{range.Address + (range.Size - 1):X6}");
-                    logger.StatusUpdateProgressBar((double)segment / maxAttempts, true);
-
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        return false;
+                        return CrcVerificationResult.Cancelled;
                     }
+
+                    logger.StatusUpdateActivity($"Processing CRC for range {range.Address:X6}-{range.Address + (range.Size - 1):X6}");
 
                     await this.vehicle.SendToolPresentNotification();
 
@@ -120,25 +114,24 @@ namespace PcmHacking
                         continue;
                     }
 
-                    int RXmaxAttempts = 5;
                     Message response = await this.vehicle.ReceiveMessage();
                     if (response == null)
+                    {
+                        consecutiveTimeouts++;
+                        if (consecutiveTimeouts >= 6)
                         {
-                        for (int j = 0; j < RXmaxAttempts; j++)
-                        {
-                            if (cancellationToken.IsCancellationRequested)
-                            {
-                                return false;
-                            }
-                            this.logger.AddDebugMessage($"CRC read failed, re-trying {range.Address.ToString("X8")} / {range.Size.ToString("X8")}");
-                            response = await this.vehicle.ReceiveMessage();
-                            if (response == null)
-                            {
-                                continue;
-                            }
+                            string detail = anyTimeout ? "" : " Kernel may have crashed.";
+                            this.logger.AddUserMessage($"PCM stopped responding during CRC check at {range.Address:X8} / {range.Size:X8}.{detail}");
+                            anyTimeout = true;
                             break;
                         }
+                        this.logger.AddDebugMessage($"CRC no response, re-querying {range.Address.ToString("X8")} / {range.Size.ToString("X8")}");
+                        await Task.Delay(retryDelay);
+                        continue;
                     }
+
+                    consecutiveTimeouts = 0;
+
                     Response<UInt32> crcResponse = this.protocol.ParseCrc(response, range.Address, range.Size);
                     if (crcResponse.Status != ResponseStatus.Success)
                     {
@@ -149,48 +142,35 @@ namespace PcmHacking
                     crc = crcResponse.Value;
                     break;
                 }
+
                 logger.StatusUpdateProgressBar(0, false);
 
                 if (!success)
                 {
-                    this.logger.AddUserMessage("Unable to get CRC for memory range " + range.Address.ToString("X8") + " / " + range.Size.ToString("X8"));
-                    successForAllRanges = false;
+                    if (!anyTimeout)
+                    {
+                        this.logger.AddUserMessage("Unable to get CRC for memory range " + range.Address.ToString("X8") + " / " + range.Size.ToString("X8"));
+                    }
+                    anyMismatch = true;
                     continue;
                 }
 
                 this.vehicle.ClearDeviceMessageQueue();
 
                 range.ActualCrc = crc;
-               
-                this.logger.AddUserMessage(
-                    string.Format(
-                        formatString,
-                        range.Address,
-                        range.Address + (range.Size - 1),
-                        range.DesiredCrc,
-                        range.ActualCrc,
-                        range.DesiredCrc == range.ActualCrc ? "Same" : "Different",
-                        range_type));
+
+                bool match = range.DesiredCrc == range.ActualCrc;
+                if (!match) anyMismatch = true;
+
+                this.logger.AddUserMessage(string.Format(formatString, range.Address, range.Address + (range.Size - 1), range.DesiredCrc, range.ActualCrc, match ? "Same" : "Different", range_type));
             }
 
             await this.vehicle.SendToolPresentNotification();
-
-            foreach (MemoryRange range in this.ranges)
-            {
-                if ((range.Type & blockTypes) == 0)
-                {
-                    continue;
-                }
-
-                if (range.ActualCrc != range.DesiredCrc)
-                {
-                    return false;
-                }
-            }
-
             this.vehicle.ClearDeviceMessageQueue();
 
-            return successForAllRanges;
+            if (anyTimeout) return CrcVerificationResult.Timeout;
+            if (anyMismatch) return CrcVerificationResult.Mismatch;
+            return CrcVerificationResult.Verified;
         }
     }
 }

--- a/Apps/PcmLibrary/CKernelWriter.cs
+++ b/Apps/PcmLibrary/CKernelWriter.cs
@@ -279,10 +279,18 @@ namespace PcmHacking
             {
                 logger.StatusUpdateReset();
 
-                if (await verifier.CompareRanges(
+                CrcVerificationResult verificationResult = await verifier.CompareRanges(
                     image,
                     relevantBlocks,
-                    cancellationToken))
+                    cancellationToken);
+
+                if (verificationResult == CrcVerificationResult.Timeout)
+                {
+                    this.logger.AddUserMessage("PCM stopped responding during write verification. Aborting.");
+                    return false;
+                }
+
+                if (verificationResult == CrcVerificationResult.Verified)
                 {
                     allRangesMatch = true;
 

--- a/Apps/PcmLibrary/Messages/Protocol.Utility.cs
+++ b/Apps/PcmLibrary/Messages/Protocol.Utility.cs
@@ -125,6 +125,11 @@ namespace PcmHacking
         /// </summary>
         private bool TryVerifyInitialBytes(Message actual, byte[] expected, out ResponseStatus status)
         {
+            if (actual == null)
+            {
+                status = ResponseStatus.Timeout;
+                return false;
+            }
             return TryVerifyInitialBytes(actual.GetBytes(), expected, out status);
         }
 

--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -106,20 +106,6 @@ namespace PcmHacking
                 return PcmType.Undefined;
             }
 
-            if (type == PcmType.P05)
-            {
-                UInt32 fileOsid = this.GetOsidFromImage(type);
-                if (fileOsid != 0)
-                {
-                    OSIDInfo osidInfo = new OSIDInfo(fileOsid);
-                    if (osidInfo.HardwareType == PcmType.P05b)
-                    {
-                        this.logger.AddDebugMessage("P05->P05b detection from OSID lookup.");
-                        return PcmType.P05b;
-                    }
-                }
-            }
-
             return type;
         }
 
@@ -624,6 +610,12 @@ namespace PcmHacking
                         (image[0x20883] == 0x01) && (image[0x20884] == 0x23) && (image[0x20885] == 0x80))
                     {
                         return PcmType.P05c;
+                    }
+
+                    UInt32 osid = ReadUnsigned(image, 0xFFFFA);
+                    if (osid != 0 && new OSIDInfo(osid).HardwareType == PcmType.P05b)
+                    {
+                        return PcmType.P05b;
                     }
                     return PcmType.P05;
                 }

--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -96,6 +96,34 @@ namespace PcmHacking
         }
 
         /// <summary>
+        /// Identify the file type without logging or validating checksums.
+        /// Returns Undefined if the file is unrecognised or structurally invalid.
+        /// </summary>
+        public PcmType GetFileType()
+        {
+            if (!this.TryPrepareValidation(out PcmType type))
+            {
+                return PcmType.Undefined;
+            }
+
+            if (type == PcmType.P05)
+            {
+                UInt32 fileOsid = this.GetOsidFromImage(type);
+                if (fileOsid != 0)
+                {
+                    OSIDInfo osidInfo = new OSIDInfo(fileOsid);
+                    if (osidInfo.HardwareType == PcmType.P05b)
+                    {
+                        this.logger.AddDebugMessage("P05->P05b detection from OSID lookup.");
+                        return PcmType.P05b;
+                    }
+                }
+            }
+
+            return type;
+        }
+
+        /// <summary>
         /// Indicate whether the image is valid or not.
         /// </summary>
         /// <returns></returns>
@@ -129,23 +157,14 @@ namespace PcmHacking
 
             try
             {
-                if (!this.TryPrepareValidation(out PcmType type))
+                PcmType type = this.GetFileType();
+                if (type == PcmType.Undefined)
                 {
                     return false;
                 }
 
                 UInt32 fileOsid = this.GetOsidFromImage(type);
                 this.logger.AddUserMessage("File operating system ID: " + fileOsid);
-
-                if (type == PcmType.P05 && fileOsid != 0)
-                {
-                    OSIDInfo osidInfo = new OSIDInfo(fileOsid);
-                    if (osidInfo.HardwareType == PcmType.P05b)
-                    {
-                        type = PcmType.P05b;
-                        this.logger.AddDebugMessage("P05->P05b detection from OSID lookup.");
-                    }
-                }
 
                 return this.ValidateChecksums(type);
             }
@@ -244,6 +263,7 @@ namespace PcmHacking
 
                 case PcmType.P05:
                 case PcmType.P05b:
+                case PcmType.P05c:
                     if (ReadUnsigned(image, 0x20882) == 0x012380)
                     {
                         logger.AddDebugMessage("P05c Variant, Reading OSID from ASCII at 0x208AA");
@@ -316,6 +336,7 @@ namespace PcmHacking
                 case PcmType.P04_Early:
                 case PcmType.P05:
                 case PcmType.P05b:
+                case PcmType.P05c:
                 case PcmType.P08:
                 case PcmType.P11:
                 case PcmType.E54:
@@ -335,6 +356,7 @@ namespace PcmHacking
                 case PcmType.P04:
                 case PcmType.P05:
                 case PcmType.P05b:
+                case PcmType.P05c:
                     success &= ValidateParamBlockP04();
                     if (ReadUnsigned(image, 0x20882) == 0x012380) { // P05c special case
                         this.logger.AddUserMessage("\tStart\tEnd\tStored\tNeeded\tVerdict\tSegment Name");
@@ -501,7 +523,6 @@ namespace PcmHacking
                 this.logger.AddDebugMessage("Trying P04 256KiB");
                 if ((image[0x3FFFE] == 0xA5) && (image[0x3FFFF] == 0x5A))
                 {
-                    this.logger.AddUserMessage("File is P04 256KiB.");
                     return PcmType.P04_Early;
                 }
             }
@@ -517,7 +538,6 @@ namespace PcmHacking
                     if ((image[0x7FFFE] == 0x4A) && (image[0x7FFFF] == 0xFC))
                     {
                         if ((image[0x3FFC] == 0) && (image[0x3FFD] == 0) && (image[0x3FFE] == 0) && (image[0x3FFF] == 0)) { // This prevents 98/99 Black Box being detected at E54
-                            this.logger.AddUserMessage("File is E54 512KiB.");
                             return PcmType.E54;
                         }
                     }
@@ -531,7 +551,6 @@ namespace PcmHacking
                     {
                         if ((image[0x20002] == 00) && (image[0x20003] == 01) && (image[0x2000A] == 01) && (image[0x2000B] == 00))
                         {
-                            this.logger.AddUserMessage("File is Vortec BlackBox 512KiB.");
                             return PcmType.BlackBox;
                         }
                     }
@@ -543,7 +562,6 @@ namespace PcmHacking
                 {
                     if ((image[0x7FFFE] == 0x4A) && (image[0x7FFFF] == 0xFC))
                     {
-                        this.logger.AddUserMessage("File is P01 512KiB.");
                         return PcmType.P01;
                     }
                 }
@@ -556,7 +574,6 @@ namespace PcmHacking
                 if (((image[0x7FFFE] == 0xA5) && (image[0x7FFFF] == 0x5A)) || // most P04 OR
                     ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A) && (image[0x7FFFE] == 0xFF) && (image[0x7FFFF] == 0xFF)))   // Most 1998 512Kb eg Malibu 09369193, Olds 09352676, LeSabre 09379801...
                 {
-                    this.logger.AddUserMessage("File is P04 512KiB.");
                     return PcmType.P04;
                 }
 
@@ -567,7 +584,6 @@ namespace PcmHacking
                     {
                         if ((image[0x534] == 0) && (image[0x535] == 00))
                         {
-                            this.logger.AddUserMessage("File is P10 512KiB.");
                             return PcmType.P10;
                         }
                     }
@@ -577,7 +593,6 @@ namespace PcmHacking
                 this.logger.AddDebugMessage("Trying P11 512KiB boot hash + marker");
                 if (this.HasP11TailMarkerAt7FFFC() && this.IsKnownP11BootSector())
                 {
-                    this.logger.AddUserMessage("File is P11 512KiB.");
                     return PcmType.P11;
                 }
 
@@ -585,7 +600,6 @@ namespace PcmHacking
                 this.logger.AddDebugMessage("Trying P08 512KiB");
                 if ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A) && (image[0x7FFFE] == 0xA5) && (image[0x7FFFF] == 0xA5))
                 {
-                    this.logger.AddUserMessage("File is P08 512KiB.");
                     return PcmType.P08;
                 }
             }
@@ -598,7 +612,6 @@ namespace PcmHacking
                 {
                     if ((image[0xFFFFE] == 0x4A) && (image[0xFFFFF] == 0xFC))
                     {
-                        this.logger.AddUserMessage("File is P59 1024KiB.");
                         return PcmType.P59;
                     }
                 }
@@ -610,11 +623,7 @@ namespace PcmHacking
                     if ((image[0x1FFFE] == 0xA5) && (image[0x1FFFF] == 0x5A) &&
                         (image[0x20883] == 0x01) && (image[0x20884] == 0x23) && (image[0x20885] == 0x80))
                     {
-                        this.logger.AddUserMessage("File is P05c 1024KiB.");
-                    }
-                    else
-                    {
-                        this.logger.AddUserMessage("File is P05 1024KiB.");
+                        return PcmType.P05c;
                     }
                     return PcmType.P05;
                 }
@@ -623,14 +632,12 @@ namespace PcmHacking
                 this.logger.AddDebugMessage("Trying P11 1024KiB boot hash + marker");
                 if (this.HasP11TailMarkerAt7FFFC() && this.IsKnownP11BootSector())
                 {
-                    this.logger.AddUserMessage("File is P11 1024KiB.");
                     return PcmType.P11;
                 }
 
                 this.logger.AddDebugMessage("Trying P12 1024KiB");
                 if ((image[0xFFFF8] == 0xAA) && (image[0xFFFF9] == 0x55))
                 {
-                    this.logger.AddUserMessage("File is P12 1024KiB.");
                     return PcmType.P12;
                 }
             }
@@ -641,7 +648,6 @@ namespace PcmHacking
                 this.logger.AddDebugMessage("Trying P12 2048KiB");
                 if ((image[0x17FFF8] == 0xAA) && (image[0x17FFF9] == 0x55))
                 {
-                    this.logger.AddUserMessage("File is P12 2048KiB.");
                     return PcmType.P12;
                 }
             }
@@ -726,6 +732,7 @@ namespace PcmHacking
 
                     case PcmType.P05: // Only used for P05c, Other P05s use P04 routines.
                     case PcmType.P05b:
+                    case PcmType.P05c:
                         if (address == 0x4000)
                         {
                             address = 0x20000;
@@ -1084,6 +1091,7 @@ namespace PcmHacking
 
                 case PcmType.P05:
                 case PcmType.P05b:
+                case PcmType.P05c:
                     return this.HasSize(1024 * 1024) &&
                         this.HasRange(0x20882, 4, "P05 variant marker") &&
                         this.HasRange(0xFFFFA, 4, "P05 OSID");

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -15,6 +15,7 @@ namespace PcmHacking
         P04,
         P05,
         P05b,
+        P05c,
         P08,
         P10,
         P11,
@@ -316,6 +317,15 @@ namespace PcmHacking
                     this.FlashIDSupport = true;
                     this.KernelVersionSupport = true;
                     this.KernelMaxBlockSize = 4096;
+                    break;
+
+                case PcmType.P05c:
+                    this.Description = "P05c (CAN only)";
+                    this.HardwareType = PcmType.P05c;
+                    this.IsSupported = false;
+                    this.IsSupportedRead = false;
+                    this.IsSupportedWrite = false;
+                    this.ImageSize = 1024 * 1024;
                     break;
 
                 case PcmType.P05b:

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -320,7 +320,7 @@ namespace PcmHacking
                     break;
 
                 case PcmType.P05c:
-                    this.Description = "P05c (CAN only)";
+                    this.Description = "P05c (CAN only, unsupported)";
                     this.HardwareType = PcmType.P05c;
                     this.IsSupported = false;
                     this.IsSupportedRead = false;

--- a/Apps/PcmLibrary/Misc/Response.cs
+++ b/Apps/PcmLibrary/Misc/Response.cs
@@ -45,6 +45,11 @@ namespace PcmHacking
         /// The request was refused.
         /// </summary>
         Refused = 6,
+
+        /// <summary>
+        /// The operation completed but the result could not be verified (e.g. CRC timed out).
+        /// </summary>
+        Unverified = 7,
     }
 
     /// <summary>

--- a/Apps/PcmLibrary/ReadManager.cs
+++ b/Apps/PcmLibrary/ReadManager.cs
@@ -44,11 +44,23 @@ namespace PcmHacking
 
         public async Task<bool> Read(string path, PcmType forcedPcmType = PcmType.Undefined)
         {
-            Stream? readContents = await Read((IProgress<ProgressUpdate>?)null, forcedPcmType);
-            if (readContents == null)
+            Response<Stream> readResponse = await RunRead(null, forcedPcmType);
+            if (readResponse == null || readResponse.Value == null)
             {
                 return false;
             }
+
+            Stream readContents = readResponse.Value;
+
+            if (readResponse.Status == ResponseStatus.Unverified)
+            {
+                path = GetBadReadPath(path);
+                this.logger.AddUserMessage("##############################################################################");
+                this.logger.AddUserMessage("WARNING: Verification timed out. File could not be validated and may be corrupt.");
+                this.logger.AddUserMessage("Saved to " + path + " for debugging only. Do not use this file without validation.");
+                this.logger.AddUserMessage("##############################################################################");
+            }
+
             // Save the contents to the path that the user provided.
             while (true)
             {
@@ -81,17 +93,35 @@ namespace PcmHacking
                     }
                 }
             }
-
         }
 
         /// <summary>
         /// Contains cross-platform code to handle user interactions to read the PCM's flash memory.
         /// </summary>
-        /// <remarks>
-        /// The return value should be used to suppress future warnings about using an unproven connection.
-        /// </remarks>
-        /// <returns>True if the read was successful, fales if failed or aborted.</returns>
+        /// <returns>The stream on success or unverified read; null on failure or abort.</returns>
         public async Task<Stream?> Read(IProgress<ProgressUpdate>? progress = null, PcmType forcedPcmType = PcmType.Undefined)
+        {
+            Response<Stream> readResponse = await RunRead(progress, forcedPcmType);
+            if (readResponse == null || readResponse.Value == null)
+            {
+                return null;
+            }
+            if (readResponse.Status == ResponseStatus.Success || readResponse.Status == ResponseStatus.Unverified)
+            {
+                return readResponse.Value;
+            }
+            return null;
+        }
+
+        private static string GetBadReadPath(string path)
+        {
+            string dir = Path.GetDirectoryName(path);
+            string name = Path.GetFileNameWithoutExtension(path);
+            string ext = Path.GetExtension(path);
+            return Path.Combine(dir, name + "_badread" + ext);
+        }
+
+        private async Task<Response<Stream>> RunRead(IProgress<ProgressUpdate>? progress, PcmType forcedPcmType)
         {
             OSIDInfo pcmInfo;
             if (forcedPcmType != PcmType.Undefined)
@@ -117,7 +147,6 @@ namespace PcmHacking
 
                 if (osidResponse.Status == ResponseStatus.Success)
                 {
-                    // Look up the information about this PCM, based on the OSID;
                     this.logger.AddUserMessage("OSID: " + osidResponse.Value);
                     pcmInfo = new OSIDInfo(osidResponse.Value);
                     this.logger.AddUserMessage("Description: " + pcmInfo.Description);
@@ -132,13 +161,12 @@ namespace PcmHacking
                     await this.invoke(async () => OperatingSystemId = await this.promptForOperatingSystemId());
                     await this.vehicle.ForceSendToolPresentNotification();
 
-                    pcmInfo = new OSIDInfo(OperatingSystemId); // osid
+                    pcmInfo = new OSIDInfo(OperatingSystemId);
 
                     this.logger.AddUserMessage($"Using OsID: {pcmInfo.OSID}");
                 }
             }
 
-            // Pre flight checks to block invalid write operations by PCM type.
             if (!pcmInfo.IsSupported)
             {
                 string msg = $"Abort: The connected {pcmInfo.HardwareType.ToString()} PCM is not supported.";
@@ -160,7 +188,7 @@ namespace PcmHacking
                 string msg = $"WARNING: {pcmInfo.HardwareType.ToString()} Support is still in development.";
                 this.logger.AddUserMessage(msg);
                 bool shouldContinue = false;
-                await this.invoke(async () => { shouldContinue = await this.promptForYesNo(msg, "Continue?"); });                
+                await this.invoke(async () => { shouldContinue = await this.promptForYesNo(msg, "Continue?"); });
                 if (!shouldContinue)
                 {
                     this.logger.AddUserMessage("User chose not to proceed.");
@@ -184,7 +212,6 @@ namespace PcmHacking
                 return null;
             }
 
-            // Do the actual reading.
             DateTime start = DateTime.Now;
 
             CKernelReader reader = new CKernelReader(
@@ -195,12 +222,14 @@ namespace PcmHacking
             Response<Stream> readResponse = await reader.ReadContents(this.cancellationToken, progress);
 
             this.logger.AddUserMessage("Elapsed time " + DateTime.Now.Subtract(start));
-            if (readResponse.Status != ResponseStatus.Success)
+
+            if (readResponse.Status != ResponseStatus.Success && readResponse.Status != ResponseStatus.Unverified)
             {
                 this.logger.AddUserMessage("Read failed, " + readResponse.Status.ToString());
                 return null;
             }
-            return readResponse.Value;
+
+            return readResponse;
         }
     }
 }

--- a/Apps/PcmLibrary/ReadManager.cs
+++ b/Apps/PcmLibrary/ReadManager.cs
@@ -42,9 +42,9 @@ namespace PcmHacking
             this.cancellationToken = cancellationToken;
         }
 
-        public async Task<bool> Read(string path)
+        public async Task<bool> Read(string path, PcmType forcedPcmType = PcmType.Undefined)
         {
-            Stream? readContents = await Read();
+            Stream? readContents = await Read((IProgress<ProgressUpdate>?)null, forcedPcmType);
             if (readContents == null)
             {
                 return false;
@@ -91,43 +91,51 @@ namespace PcmHacking
         /// The return value should be used to suppress future warnings about using an unproven connection.
         /// </remarks>
         /// <returns>True if the read was successful, fales if failed or aborted.</returns>
-        public async Task<Stream?> Read(IProgress<ProgressUpdate>? progress = null)
+        public async Task<Stream?> Read(IProgress<ProgressUpdate>? progress = null, PcmType forcedPcmType = PcmType.Undefined)
         {
-            this.logger.AddUserMessage("Querying operating system of current PCM.");
-            Response<uint> osidResponse = await this.vehicle.QueryOperatingSystemId(this.cancellationToken);
-            if (osidResponse.Status != ResponseStatus.Success)
-            {
-                this.logger.AddUserMessage("Operating system query failed, will retry: " + osidResponse.Status);
-                await this.vehicle.ExitKernel();
-
-                osidResponse = await this.vehicle.QueryOperatingSystemId(this.cancellationToken);
-                if (osidResponse.Status != ResponseStatus.Success)
-                {
-                    this.logger.AddUserMessage("Operating system query failed: " + osidResponse.Status);
-                }
-            }
-
             OSIDInfo pcmInfo;
-            if (osidResponse.Status == ResponseStatus.Success)
+            if (forcedPcmType != PcmType.Undefined)
             {
-                // Look up the information about this PCM, based on the OSID;
-                this.logger.AddUserMessage("OSID: " + osidResponse.Value);
-                pcmInfo = new OSIDInfo(osidResponse.Value);
-                this.logger.AddUserMessage("Description: " + pcmInfo.Description);
+                pcmInfo = new OSIDInfo(forcedPcmType);
+                this.logger.AddUserMessage("Using manually selected PCM type: " + pcmInfo.HardwareType);
             }
             else
             {
-                this.logger.AddUserMessage("Unable to get operating system ID. Will assume this can be unlocked with the default seed/key algorithm.");
+                this.logger.AddUserMessage("Querying operating system of current PCM.");
+                Response<uint> osidResponse = await this.vehicle.QueryOperatingSystemId(this.cancellationToken);
+                if (osidResponse.Status != ResponseStatus.Success)
+                {
+                    this.logger.AddUserMessage("Operating system query failed, will retry: " + osidResponse.Status);
+                    await this.vehicle.ExitKernel();
 
-                UInt32 OperatingSystemId = 0;
+                    osidResponse = await this.vehicle.QueryOperatingSystemId(this.cancellationToken);
+                    if (osidResponse.Status != ResponseStatus.Success)
+                    {
+                        this.logger.AddUserMessage("Operating system query failed: " + osidResponse.Status);
+                    }
+                }
 
-                await this.vehicle.ForceSendToolPresentNotification();
-                await this.invoke(async () => OperatingSystemId = await this.promptForOperatingSystemId());
-                await this.vehicle.ForceSendToolPresentNotification();
+                if (osidResponse.Status == ResponseStatus.Success)
+                {
+                    // Look up the information about this PCM, based on the OSID;
+                    this.logger.AddUserMessage("OSID: " + osidResponse.Value);
+                    pcmInfo = new OSIDInfo(osidResponse.Value);
+                    this.logger.AddUserMessage("Description: " + pcmInfo.Description);
+                }
+                else
+                {
+                    this.logger.AddUserMessage("Unable to get operating system ID. Will assume this can be unlocked with the default seed/key algorithm.");
 
-                pcmInfo = new OSIDInfo(OperatingSystemId); // osid
+                    UInt32 OperatingSystemId = 0;
 
-                this.logger.AddUserMessage($"Using OsID: {pcmInfo.OSID}");
+                    await this.vehicle.ForceSendToolPresentNotification();
+                    await this.invoke(async () => OperatingSystemId = await this.promptForOperatingSystemId());
+                    await this.vehicle.ForceSendToolPresentNotification();
+
+                    pcmInfo = new OSIDInfo(OperatingSystemId); // osid
+
+                    this.logger.AddUserMessage($"Using OsID: {pcmInfo.OSID}");
+                }
             }
 
             // Pre flight checks to block invalid write operations by PCM type.

--- a/Apps/PcmLibrary/WriteManager.cs
+++ b/Apps/PcmLibrary/WriteManager.cs
@@ -39,7 +39,7 @@ namespace PcmHacking
         /// Accepts a string path for OSes that can directly access file structure.
         /// </summary>
         /// <returns>True if file opens and write succeeds. False if either condition fails.</returns>
-        public async Task<bool> Write(string path)
+        public async Task<bool> Write(string path, PcmType forcedPcmType = PcmType.Undefined)
         {
             byte[] image;
             using (Stream stream = File.OpenRead(path))
@@ -53,7 +53,7 @@ namespace PcmHacking
                     return false;
                 }
             }
-            return await Write(image);
+            return await Write(image, forcedPcmType);
         }
 
         /// <summary>
@@ -64,15 +64,17 @@ namespace PcmHacking
         /// The return value should be used to suppress future warnings about using an unproven connection.
         /// </remarks>
         /// <returns>True if the write was successful, fales if failed or aborted.</returns>
-        public async Task<bool> Write(byte[] image)
+        public async Task<bool> Write(byte[] image, PcmType forcedPcmType = PcmType.Undefined)
         {
-            // Sanity checks. 
-            FileValidator validator = new FileValidator(image, this.logger);
+            // Sanity checks.
+            PcmType? forcedFileType = forcedPcmType != PcmType.Undefined ? forcedPcmType : (PcmType?)null;
+            FileValidator validator = new FileValidator(image, this.logger, forcedFileType);
             if (!validator.IsValid())
             {
                 this.logger.AddUserMessage("This file is corrupt or its format is unknown to PCMHammer. It would render your PCM unusable.");
                 return false;
             }
+            this.logger.AddUserMessage("File is " + new OSIDInfo(validator.GetFileType()).Description + ".");
 
             UInt32 kernelVersion = 0;
             bool needUnlock;
@@ -84,86 +86,97 @@ namespace PcmHacking
                 (writeType != WriteType.Full) &&
                 (writeType != WriteType.TestWrite);
 
-            this.logger.AddUserMessage("Requesting operating system ID...");
-            Response<uint> osidResponse = await this.vehicle.QueryOperatingSystemId(this.cancellationToken);
-            if (osidResponse.Status == ResponseStatus.Success)
+            if (forcedPcmType != PcmType.Undefined)
             {
-                pcmInfo = new OSIDInfo(osidResponse.Value);
+                pcmInfo = new OSIDInfo(forcedPcmType);
                 keyAlgorithm = pcmInfo.KeyAlgorithm;
                 needUnlock = true;
-
-                if (!validator.IsSameHardware(osidResponse.Value))
-                {
-                    return false;
-                }
-
-                if (!validator.IsSameOperatingSystem(osidResponse.Value))
-                {
-                    Utility.ReportOperatingSystems(validator.GetOsidFromImage(), osidResponse.Value, writeType, this.logger, out shouldHalt);
-                    if (shouldHalt)
-                    {
-                        return false;
-                    }
-                }
-
                 needToCheckOperatingSystem = false;
+                this.logger.AddUserMessage("Using manually selected PCM type: " + pcmInfo.HardwareType);
             }
             else
             {
-                if (this.cancellationToken.IsCancellationRequested)
+                this.logger.AddUserMessage("Requesting operating system ID...");
+                Response<uint> osidResponse = await this.vehicle.QueryOperatingSystemId(this.cancellationToken);
+                if (osidResponse.Status == ResponseStatus.Success)
                 {
-                    return false;
-                }
+                    pcmInfo = new OSIDInfo(osidResponse.Value);
+                    keyAlgorithm = pcmInfo.KeyAlgorithm;
+                    needUnlock = true;
 
-                this.logger.AddUserMessage("Operating system request failed, checking for a live kernel...");
-
-                kernelVersion = await this.vehicle.GetKernelVersion();
-                if (kernelVersion == 0)
-                {
-                    this.logger.AddUserMessage("Checking for recovery mode...");
-                    bool recoveryMode = await this.vehicle.IsInRecoveryMode();
-
-                    if (recoveryMode)
+                    if (!validator.IsSameHardware(osidResponse.Value))
                     {
-                        this.logger.AddUserMessage("PCM is in recovery mode.");
-                        needUnlock = true;
+                        return false;
                     }
-                    else
+
+                    if (!validator.IsSameOperatingSystem(osidResponse.Value))
                     {
-                        this.logger.AddUserMessage("PCM is not responding to OSID, kernel version, or recovery mode checks.");
-                        this.logger.AddUserMessage("Unlock may not work, but we'll try...");
-                        needUnlock = true;
-                    }
-                    pcmInfo = new OSIDInfo(validator.GetOsidFromImage()); // Prevent Null Reference Exceptions from breaking Recovery Mode
-                }
-                else
-                {
-                    needUnlock = false;
-
-                    this.logger.AddUserMessage("Kernel version: " + kernelVersion.ToString("X8"));
-
-                    this.logger.AddUserMessage("Asking kernel for the PCM's operating system ID...");
-
-                    if (needToCheckOperatingSystem)
-                    {
-                        osidResponse = await this.vehicle.QueryOperatingSystemIdFromKernel(this.cancellationToken);
-                        if (osidResponse.Status != ResponseStatus.Success)
-                        {
-                            // The kernel seems broken. This shouldn't happen, but if it does, halt.
-                            this.logger.AddUserMessage("The kernel did not respond to operating system ID query.");
-                            return false;
-                        }
-
                         Utility.ReportOperatingSystems(validator.GetOsidFromImage(), osidResponse.Value, writeType, this.logger, out shouldHalt);
                         if (shouldHalt)
                         {
                             return false;
                         }
-
-                        pcmInfo = new OSIDInfo(osidResponse.Value);
                     }
 
                     needToCheckOperatingSystem = false;
+                }
+                else
+                {
+                    if (this.cancellationToken.IsCancellationRequested)
+                    {
+                        return false;
+                    }
+
+                    this.logger.AddUserMessage("Operating system request failed, checking for a live kernel...");
+
+                    kernelVersion = await this.vehicle.GetKernelVersion();
+                    if (kernelVersion == 0)
+                    {
+                        this.logger.AddUserMessage("Checking for recovery mode...");
+                        bool recoveryMode = await this.vehicle.IsInRecoveryMode();
+
+                        if (recoveryMode)
+                        {
+                            this.logger.AddUserMessage("PCM is in recovery mode.");
+                            needUnlock = true;
+                        }
+                        else
+                        {
+                            this.logger.AddUserMessage("PCM is not responding to OSID, kernel version, or recovery mode checks.");
+                            this.logger.AddUserMessage("Unlock may not work, but we'll try...");
+                            needUnlock = true;
+                        }
+                        pcmInfo = new OSIDInfo(validator.GetOsidFromImage()); // Prevent Null Reference Exceptions from breaking Recovery Mode
+                    }
+                    else
+                    {
+                        needUnlock = false;
+
+                        this.logger.AddUserMessage("Kernel version: " + kernelVersion.ToString("X8"));
+
+                        this.logger.AddUserMessage("Asking kernel for the PCM's operating system ID...");
+
+                        if (needToCheckOperatingSystem)
+                        {
+                            osidResponse = await this.vehicle.QueryOperatingSystemIdFromKernel(this.cancellationToken);
+                            if (osidResponse.Status != ResponseStatus.Success)
+                            {
+                                // The kernel seems broken. This shouldn't happen, but if it does, halt.
+                                this.logger.AddUserMessage("The kernel did not respond to operating system ID query.");
+                                return false;
+                            }
+
+                            Utility.ReportOperatingSystems(validator.GetOsidFromImage(), osidResponse.Value, writeType, this.logger, out shouldHalt);
+                            if (shouldHalt)
+                            {
+                                return false;
+                            }
+
+                            pcmInfo = new OSIDInfo(osidResponse.Value);
+                        }
+
+                        needToCheckOperatingSystem = false;
+                    }
                 }
             }
 

--- a/Apps/UI/WindowsForms/PcmHammer/Configuration.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/Configuration.cs
@@ -1,13 +1,74 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Configuration;
+using System.IO;
+using System.Windows.Forms;
 
 namespace PcmHacking
 {
     public class Configuration
     {
-        public static PcmHammer.Properties.Settings Settings = PcmHammer.Properties.Settings.Default;
+        private static PcmHammer.Properties.Settings settings;
+
+        public static PcmHammer.Properties.Settings Settings
+        {
+            get
+            {
+                if (settings == null)
+                {
+                    settings = LoadSettings();
+                }
+                return settings;
+            }
+        }
+
+        private static PcmHammer.Properties.Settings LoadSettings()
+        {
+            var s = PcmHammer.Properties.Settings.Default;
+            try
+            {
+                // Probe a property to force lazy deserialization from disk now,
+                // so corruption is caught here rather than mid-operation.
+                _ = s.MainWindowPersistence;
+                return s;
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                TryDeleteCorruptConfig(ex);
+                try
+                {
+                    // The singleton is in a broken state; create a fresh instance
+                    // so the app continues with defaults. It can save on close,
+                    // creating a clean file for the next launch.
+                    return new PcmHammer.Properties.Settings();
+                }
+                catch
+                {
+                    MessageBox.Show(
+                        "The application configuration is corrupt and could not be recovered.\n\nThe application will now close.",
+                        "Configuration Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                    Environment.Exit(1);
+                    return null;
+                }
+            }
+        }
+
+        private static void TryDeleteCorruptConfig(ConfigurationErrorsException ex)
+        {
+            try
+            {
+                string filename = ex.Filename;
+                if (string.IsNullOrEmpty(filename) && ex.InnerException is ConfigurationErrorsException inner)
+                {
+                    filename = inner.Filename;
+                }
+                if (!string.IsNullOrEmpty(filename) && File.Exists(filename))
+                {
+                    File.Delete(filename);
+                }
+            }
+            catch { }
+        }
     }
 }

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
@@ -975,9 +975,58 @@ namespace PcmHacking
         {
             if (!BackgroundWorker.IsAlive)
             {
-                BackgroundWorker = new System.Threading.Thread(() => readFullContents_BackgroundThread());
+                this.StartOperationFromDialog(false, WriteType.Full);
+            }
+        }
+
+        private void StartOperationFromDialog(bool defaultIsWrite, WriteType defaultWriteType)
+        {
+            using (OperationSelectionDialogBox dialog = new OperationSelectionDialogBox(defaultIsWrite, defaultWriteType))
+            {
+                DialogResult result = dialog.ShowDialog(this);
+                if (result != DialogResult.OK || dialog.Selection == null)
+                {
+                    return;
+                }
+
+                OperationSelection selection = dialog.Selection;
+
+                if (selection.IsWrite)
+                {
+                    if (!ConfirmBeforeWrite(this.GetWriteConfirmationText(selection.WriteType)))
+                    {
+                        return;
+                    }
+
+                    BackgroundWorker = new System.Threading.Thread(
+                        () => write_BackgroundThread(selection.WriteType, null, selection.UseAutoPcmType, selection.SelectedPcmType));
+                }
+                else
+                {
+                    BackgroundWorker = new System.Threading.Thread(
+                        () => readFullContents_BackgroundThread(selection.UseAutoPcmType, selection.SelectedPcmType));
+                }
+
                 BackgroundWorker.IsBackground = true;
                 BackgroundWorker.Start();
+            }
+        }
+
+        private string GetWriteConfirmationText(WriteType writeType)
+        {
+            switch (writeType)
+            {
+                case WriteType.Parameters:
+                    return "This will update the parameter block on your PCM.";
+
+                case WriteType.OsPlusCalibrationPlusBoot:
+                    return "This will replace the operating system and calibration on your PCM.";
+
+                case WriteType.Full:
+                    return "This will replace the contents of the flash memory on your PCM.";
+
+                default:
+                    return "This will update your PCM.";
             }
         }
 
@@ -1033,12 +1082,7 @@ namespace PcmHacking
         {
             if (!BackgroundWorker.IsAlive)
             {
-                if (ConfirmBeforeWrite("This will update the calibration on your PCM."))
-                { 
-                    BackgroundWorker = new System.Threading.Thread(() => write_BackgroundThread(WriteType.Calibration));
-                    BackgroundWorker.IsBackground = true;
-                    BackgroundWorker.Start();
-                }
+                this.StartOperationFromDialog(true, WriteType.OsPlusCalibrationPlusBoot);
             }
         }
 
@@ -1049,12 +1093,7 @@ namespace PcmHacking
         {
             if (!BackgroundWorker.IsAlive)
             {
-                if (ConfirmBeforeWrite("This will update the parameter block on your PCM."))
-                {
-                    BackgroundWorker = new System.Threading.Thread(() => write_BackgroundThread(WriteType.Parameters));
-                    BackgroundWorker.IsBackground = true;
-                    BackgroundWorker.Start();
-                }
+                this.StartOperationFromDialog(true, WriteType.Parameters);
             }
         }
 
@@ -1065,12 +1104,7 @@ namespace PcmHacking
         {
             if (!BackgroundWorker.IsAlive)
             {
-                if (ConfirmBeforeWrite("This will replace the operating system and calibration on your PCM."))
-                {
-                    BackgroundWorker = new System.Threading.Thread(() => write_BackgroundThread(WriteType.OsPlusCalibrationPlusBoot));
-                    BackgroundWorker.IsBackground = true;
-                    BackgroundWorker.Start();
-                }
+                this.StartOperationFromDialog(true, WriteType.OsPlusCalibrationPlusBoot);
             }
         }
 
@@ -1081,12 +1115,7 @@ namespace PcmHacking
         {
             if (!BackgroundWorker.IsAlive)
             {
-                if (ConfirmBeforeWrite("This will replace the contents of the flash memory on your PCM."))
-                { 
-                    BackgroundWorker = new System.Threading.Thread(() => write_BackgroundThread(WriteType.Full));
-                    BackgroundWorker.IsBackground = true;
-                    BackgroundWorker.Start();
-                }
+                this.StartOperationFromDialog(true, WriteType.Full);
             }
         }
 
@@ -1167,7 +1196,7 @@ namespace PcmHacking
         /// <summary>
         /// Read the entire contents of the flash.
         /// </summary>
-        private async void readFullContents_BackgroundThread()
+        private async void readFullContents_BackgroundThread(bool useAutoPcmType = true, PcmType selectedPcmType = PcmType.Undefined)
         {
             using (new AwayMode())
             {
@@ -1181,7 +1210,7 @@ namespace PcmHacking
 
                     if (this.Vehicle == null)
                     {
-                        // This shouldn't be possible - it would mean the buttons 
+                        // This shouldn't be possible - it would mean the buttons
                         // were enabled when they shouldn't be.
                         return;
                     }
@@ -1196,6 +1225,8 @@ namespace PcmHacking
                         return;
                     }
 
+                    PcmType forcedPcmType = useAutoPcmType ? PcmType.Undefined : selectedPcmType;
+
                     this.cancellationTokenSource = new CancellationTokenSource();
                     ReadManager readManager = new ReadManager(
                         this,
@@ -1207,7 +1238,7 @@ namespace PcmHacking
                         this.PromptForYesNo,
                         this.cancellationTokenSource.Token);
 
-                    if (await readManager.Read(path))
+                    if (await readManager.Read(path, forcedPcmType))
                     {
                         // This will suppress the scary warnings prior to writing.
                         Configuration.Settings.ConnectionVerified = true;
@@ -1281,7 +1312,7 @@ namespace PcmHacking
         /// <summary>
         /// Write changes to the PCM's flash memory.
         /// </summary>
-        private async void write_BackgroundThread(WriteType writeType, string path = null)
+        private async void write_BackgroundThread(WriteType writeType, string path = null, bool useAutoPcmType = true, PcmType selectedPcmType = PcmType.Undefined)
         {
             using (new AwayMode())
             {
@@ -1332,15 +1363,17 @@ namespace PcmHacking
 
                     this.AddUserMessage(path);
 
+                    PcmType forcedPcmType = useAutoPcmType ? PcmType.Undefined : selectedPcmType;
+
                     WriteManager writer = new WriteManager(
                         this,
                         this.Vehicle,
-                         writeType,
+                        writeType,
                         this.Alert,
                         this.PromptForYesNo,
                         this.cancellationTokenSource.Token);
 
-                    bool success = await writer.Write(path);
+                    bool success = await writer.Write(path, forcedPcmType);
 
                     if (success)
                     {
@@ -1451,6 +1484,7 @@ namespace PcmHacking
             FileValidator validator = new FileValidator(image, this);
             if (validator.IsValid())
             {
+                this.AddUserMessage("File is " + new OSIDInfo(validator.GetFileType()).Description + ".");
                 this.AddUserMessage("All checksums are valid.");
             }
             else

--- a/Apps/UI/WindowsForms/PcmLibraryWindowsForms/ContentLoader.cs
+++ b/Apps/UI/WindowsForms/PcmLibraryWindowsForms/ContentLoader.cs
@@ -47,6 +47,7 @@ namespace PcmHacking
             }
 
             this.logger.AddDebugMessage("Loading " + fileName + " from embedded resource.");
+            try { File.Delete(this.GetCacheFilePath()); } catch { }
             var resourceName = "PcmHammer." + fileName;
             return this.assembly.GetManifestResourceStream(resourceName);
         }
@@ -56,10 +57,9 @@ namespace PcmHacking
         /// </summary>
         private string GetFileUrl(string path)
         {
-            string urlBase = "https://raw.githubusercontent.com/LegacyNsfw/PcmHacks/";
-            string branch = this.appVersion == null ? "develop" : "Release/" + this.appVersion;
-            string result = urlBase + branch + path;
-            return result;
+            string urlBase = "https://raw.githubusercontent.com/PcmHammer/PcmHammer/";
+            string branch = this.appVersion == null ? "refs/heads/develop" : "refs/heads/Release/" + this.appVersion;
+            return urlBase + branch + path;
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace PcmHacking
             {
                 HttpRequestMessage request = new HttpRequestMessage(
                     HttpMethod.Get,
-                    GetFileUrl("/Apps/PcmHammer/" + fileName));
+                    GetFileUrl("/Apps/UI/WindowsForms/PcmHammer/" + fileName));
 
                 request.Headers.Add("Cache-Control", "no-cache");
                 HttpClient client = new HttpClient();
@@ -102,7 +102,7 @@ namespace PcmHacking
                     try
                     {
                         string path = this.GetCacheFilePath();
-                        using (Stream file = File.OpenWrite(path))
+                        using (Stream file = File.Create(path))
                         {
                             await stream.CopyToAsync(file);
                         }


### PR DESCRIPTION
the read and write ui was lost with a merge from crowbarmaster, the hooks were removed by accident from main loops. that is retored.

the next part fixed the annoying double message about file type in the user log. it wasn't possible to fix that without a refactor, and its been on the list for a long time. now that part of the code is split more logically and the implementation is more tidy. functionality is the same and the code smell is gone.

If the config file is deleted we used to crash and get in a bad state. now that is recoverable, and in the event it cant be recovered the user is advised and we cleanly exit.

The CRC functions have been improved so that if the PCM crashes on CRC test at the end of the read the app no longer crashes with it. This revealed another bug behind it that the timeout and retry logic was broken and it then took waaaaay to long to fail. That all works cleanly and quickly (by comparison) now and we also still save the file on that error with the filename changed and the user warned, so the bin is not lost even if it was not checked.