### PR TITLE
fix unexpected response messages

### DIFF
--- a/Apps/PcmLibrary/Devices/OBDXProDevice.cs
+++ b/Apps/PcmLibrary/Devices/OBDXProDevice.cs
@@ -518,21 +518,35 @@ namespace PcmHacking
             //Send frame
             await this.Port.Send(SendPacket);
 
-            // Wait for confirmation of successful send
+            // Wait for confirmation of successful send (the 0x20/0x21 TX acknowledgment).
+            //
+            // Received bus frames (0x08/0x09) arrive asynchronously on the same stream, so one
+            // can land between our send and its acknowledgment. ReadDVIPacket has already
+            // enqueued such a frame for the normal receive path and returned UnexpectedResponse;
+            // that is not a send failure, so we keep reading until the real ack (or a fault)
+            // arrives. Only genuine silence (Timeout) counts against the give-up budget.
             Response<Message>? m = null;
+            int timeouts = 0;
 
-            for (int attempt = 0; attempt < 10; attempt++)
+            for (int reads = 0; reads < 64 && timeouts < 10; reads++)
             {
                 m = await ReadDVIPacket(500);
-                if (m != null)
+                if (m == null)
                 {
-                    if (m.Status == ResponseStatus.Timeout)
-                    {
-                        continue;
-                    }
-                    break;
+                    continue;
                 }
-            }            
+                if (m.Status == ResponseStatus.Timeout)
+                {
+                    timeouts++;
+                    continue;
+                }
+                if (m.Status == ResponseStatus.UnexpectedResponse)
+                {
+                    // Unsolicited inbound bus frame, already enqueued; keep waiting for the ack.
+                    continue;
+                }
+                break;
+            }
 
             if (m == null)
             {


### PR DESCRIPTION
fix unexpected response messages when tool present messages appear between a tx and rx of the same request

[18:13:59.997]  Sending 'test device present' notification.
[18:14:00.012]  XPro: 20 01 00 DE
[18:14:00.012]  TX: 8C FE F0 3F
[18:14:00.028]  XPro: 20 01 00 DE
[18:14:00.028]  TX: 6C 10 F0 3D 02 02 00 00 06 00 00
[18:14:01.043]  Timeout.. no data present A
[18:14:01.043]  CRC no response, re-querying 00060000 / 00020000
[18:14:01.121]  XPro: 20 01 00 DE
[18:14:01.121]  TX: 6C 10 F0 3D 02 02 00 00 06 00 00
[18:14:02.137]  Timeout.. no data present A
[18:14:02.137]  CRC no response, re-querying 00060000 / 00020000
Sending 'test device present' notification. / Unable to transmit, UnexpectedResponse: 8C FE F0 3F <---------------
[18:14:02.199]  XPro: 20 01 00 DE
[18:14:02.199]  TX: 6C 10 F0 3D 02 02 00 00 06 00 00
[18:14:02.199]  060000-07FFFF	7A199297	7A199297	Same	OperatingSystem