### PR TITLE
Antus/comms filtering

### DIFF
--- a/Apps/PcmLibrary/CKernelVerifier.cs
+++ b/Apps/PcmLibrary/CKernelVerifier.cs
@@ -110,6 +110,9 @@ namespace PcmHacking
                 UInt32 crc = 0;
 
                 Message query = this.protocol.CreateCrcQuery(range.Address, range.Size);
+                // Filter inbound traffic to CRC replies from the PCM for this range's poll loop.
+                using (this.vehicle.FilterRepliesTo(query))
+                {
                 while (true)
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -155,6 +158,7 @@ namespace PcmHacking
                     crc = crcResponse.Value;
                     break;
                 }
+                } // using (FilterRepliesTo)
 
                 logger.StatusUpdateProgressBar(0, false);
 

--- a/Apps/PcmLibrary/Devices/Device.cs
+++ b/Apps/PcmLibrary/Devices/Device.cs
@@ -67,6 +67,20 @@ namespace PcmHacking
         private Queue<Message> queue = new Queue<Message>();
 
         /// <summary>
+        /// Optional predicate deciding which received messages are "on-conversation"
+        /// for the request/response exchange currently in progress. Null (the default,
+        /// outside of a Query) means accept every message, preserving legacy behavior.
+        /// </summary>
+        /// <remarks>
+        /// Installed and removed via <see cref="FilterInbound"/> so that the filter's
+        /// lifetime is exactly the exchange that set it: when the owning code stops
+        /// trying (success, error, retry exhaustion, cancellation, or an exception) the
+        /// scope is disposed and the filter is gone. A failed or aborted operation can
+        /// never leave a stale filter behind to block the next one.
+        /// </remarks>
+        private Predicate<Message>? inboundFilter;
+
+        /// <summary>
         /// For the AllPro, we need to tell the interface how long to listen for incoming messages.
         /// For other devices this is not so critical, however I suspect it might still be useful to set serial-port timeouts.
         /// </summary>
@@ -166,6 +180,13 @@ namespace PcmHacking
         /// Number of messages recevied so far.
         /// </summary>
         public int ReceivedMessageCount { get { return this.queue.Count; } }
+
+        /// <summary>
+        /// Count of received messages dropped by an active inbound filter. Useful as a
+        /// diagnostic of how much off-conversation bus traffic is being rejected
+        /// (expected to be 0 on a quiet bench, non-zero in-car).
+        /// </summary>
+        public long DroppedMessageCount { get; private set; }
 
         /// <summary>
         /// Gets the number of messages waiting in the receive queue.
@@ -316,14 +337,71 @@ namespace PcmHacking
         protected abstract void Dispose(bool disposing);
 
         /// <summary>
-        /// Add a received message to the queue.
+        /// Install an inbound message filter for the duration of one request/response
+        /// exchange. While active, received messages that the predicate rejects are
+        /// dropped (and counted) instead of being queued. Disposing the returned scope
+        /// removes the filter and restores any previously-active one.
+        /// </summary>
+        /// <remarks>
+        /// The intended owner is the request/response primitive (the Query class): it opens
+        /// the scope around its send/receive loop with a <c>using</c>, so the filter is
+        /// active exactly while that exchange is still trying and is guaranteed to be
+        /// released on every exit path. Nesting is supported; the innermost (most recent)
+        /// scope is the active one.
+        /// </remarks>
+        public InboundFilterScope FilterInbound(Predicate<Message> accept)
+        {
+            return new InboundFilterScope(this, accept);
+        }
+
+        /// <summary>
+        /// Add a received message to the queue, unless an active inbound filter rejects it.
         /// </summary>
         protected void Enqueue(Message message)
         {
+            Predicate<Message>? filter = this.inboundFilter;
+            if (filter != null && !filter(message))
+            {
+                // Off-conversation bus traffic: count it (see DroppedMessageCount) but don't
+                // log each one — in-car that would be extremely chatty.
+                this.DroppedMessageCount++;
+                return;
+            }
+
             lock (this.queue)
             {
                 this.Logger.AddDebugMessage("Received: " + message.ToString());
                 this.queue.Enqueue(message);
+            }
+        }
+
+        /// <summary>
+        /// Disposable scope that keeps an inbound filter installed on a Device for the
+        /// lifetime of one request/response exchange. Created via
+        /// <see cref="Device.FilterInbound"/>; disposing restores the prior filter.
+        /// </summary>
+        public sealed class InboundFilterScope : IDisposable
+        {
+            private readonly Device device;
+            private readonly Predicate<Message>? previous;
+            private bool disposed;
+
+            internal InboundFilterScope(Device device, Predicate<Message> accept)
+            {
+                this.device = device;
+                this.previous = device.inboundFilter;   // remember for restore (nesting)
+                device.inboundFilter = accept;           // innermost scope wins
+            }
+
+            public void Dispose()
+            {
+                if (this.disposed)
+                {
+                    return;
+                }
+
+                this.disposed = true;
+                this.device.inboundFilter = this.previous;
             }
         }
 

--- a/Apps/PcmLibrary/Misc/MessageFilters.cs
+++ b/Apps/PcmLibrary/Misc/MessageFilters.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using System;
+
+namespace PcmHacking
+{
+    /// <summary>
+    /// Builders for inbound message filters (see <see cref="Device.FilterInbound"/>).
+    /// Kept in one place so every exchange that wants to ignore off-conversation bus
+    /// traffic uses the same addressing rule rather than re-deriving it.
+    /// </summary>
+    public static class MessageFilters
+    {
+        /// <summary>
+        /// Build a filter that keeps only the replies to a given outgoing request: a VPW
+        /// message is [priority][dest][src][mode]..., so a genuine reply to a physical
+        /// request is addressed to the tool (dest == Tool) and comes from the module we
+        /// sent to (src == the request's dest). Everything else on the bus is dropped.
+        /// </summary>
+        /// <remarks>
+        /// Conservative by design: messages too short to carry addressing are accepted and
+        /// left to the response selector, so this never drops anything the legacy code would
+        /// have processed. Broadcast / functional requests (dest in the tool/broadcast range,
+        /// 0xF0-0xFF) are not narrowed by source, since replies legitimately come from many
+        /// modules.
+        /// </remarks>
+        public static Predicate<Message> RepliesFrom(Message request)
+        {
+            if (request == null || request.Length < 3)
+            {
+                return _ => true;
+            }
+
+            byte target = request[1];
+            bool broadcast = target >= 0xF0; // DeviceId.Tool (0xF0) .. Broadcast (0xFE)
+
+            return received =>
+            {
+                if (received == null || received.Length < 3)
+                {
+                    return true; // can't classify; preserve legacy behavior
+                }
+
+                if (received[1] != DeviceId.Tool)
+                {
+                    return false; // addressed to some other module — not our conversation
+                }
+
+                return broadcast || received[2] == target;
+            };
+        }
+    }
+}

--- a/Apps/PcmLibrary/Misc/Query.cs
+++ b/Apps/PcmLibrary/Misc/Query.cs
@@ -49,12 +49,27 @@ namespace PcmHacking
         /// </summary>
         private ILogger logger;
 
+        /// <summary>
+        /// Optional inbound address filter, installed on the device for the duration of
+        /// Execute(). Decides which received messages are on-conversation for this
+        /// exchange; unrelated bus traffic is dropped before it reaches the response
+        /// selector. Null means "derive a default from the outgoing request".
+        /// </summary>
+        private Func<Message, Predicate<Message>>? acceptInbound;
+
         public int MaxTimeouts { get; set; }
 
         /// <summary>
         /// Constructor.
         /// </summary>
-        public Query(Device device, Func<Message> generator, Func<Message, Response<T>> filter, ILogger logger, CancellationToken cancellationToken, ToolPresentNotifier? notifier = null)
+        /// <param name="acceptInbound">
+        /// Optional factory that, given the outgoing request, returns the predicate used
+        /// to filter inbound traffic for this exchange. When null,
+        /// <see cref="MessageFilters.RepliesFrom"/> is used: it keeps only messages addressed
+        /// to the tool from the module we queried. Pass a predicate that accepts everything
+        /// for broadcast / multi-module exchanges.
+        /// </param>
+        public Query(Device device, Func<Message> generator, Func<Message, Response<T>> filter, ILogger logger, CancellationToken cancellationToken, ToolPresentNotifier? notifier = null, Func<Message, Predicate<Message>>? acceptInbound = null)
         {
             this.device = device;
             this.generator = generator;
@@ -62,6 +77,7 @@ namespace PcmHacking
             this.logger = logger;
             this.notifier = notifier;
             this.cancellationToken = cancellationToken;
+            this.acceptInbound = acceptInbound;
             this.MaxTimeouts = 5;
         }
 
@@ -74,6 +90,13 @@ namespace PcmHacking
 
             Message request = this.generator();
 
+            // Filter inbound traffic to this conversation for as long as this exchange is
+            // trying. The 'using' guarantees the filter is removed on every exit path below
+            // (success, error, retry exhaustion, cancellation, or exception), so the filter
+            // never outlives the attempt.
+            Predicate<Message> accept = this.acceptInbound != null ? this.acceptInbound(request) : MessageFilters.RepliesFrom(request);
+            using (this.device.FilterInbound(accept))
+            {
             bool success = false;
             for (int sendAttempt = 1; sendAttempt <= 2; sendAttempt++)
             {
@@ -144,6 +167,7 @@ namespace PcmHacking
             }
 
             return Response.Create(ResponseStatus.Error, default(T)!);
+            } // using (FilterInbound)
         }
     }
 }

--- a/Apps/PcmLibrary/Misc/ToolPresentNotifier.cs
+++ b/Apps/PcmLibrary/Misc/ToolPresentNotifier.cs
@@ -74,6 +74,12 @@ namespace PcmHacking
         /// <summary>
         /// Send a tool-present message.
         /// </summary>
+        /// <remarks>
+        /// This is a fire-and-forget broadcast with no expected reply, so it sends directly
+        /// on the device rather than through a Query. That keeps it outside the Query
+        /// inbound-filter scope — there is no response to filter for, and it must not disturb
+        /// the filter belonging to whatever exchange is currently in progress.
+        /// </remarks>
         private async Task SendNotification()
         {
             logger.AddDebugMessage("Sending 'test device present' notification.");

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -685,7 +685,7 @@ namespace PcmHacking
                     continue;
                 }
 
-                if (await WaitForSuccess(this.protocol.ParseUploadResponse, cancellationToken))
+                if (await WaitForSuccess(this.protocol.ParseUploadResponse, cancellationToken, request: message))
                 {
                     return Response.Create(ResponseStatus.Success, true, retryCount);
                 }

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -563,6 +563,10 @@ namespace PcmHacking
 
                 // Check for any devices that refused to switch to 4X speed.
                 // These responses usually get lost, so this code might be pointless.
+                // Like RequestHighSpeedPermission above, this listens directly on the device
+                // rather than via Query<T>: the refusals can come from any module on the bus,
+                // and Query<T>'s inbound filter would drop everything except replies from a
+                // single addressed module.
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
@@ -610,6 +614,11 @@ namespace PcmHacking
         /// </summary>
         private async Task<List<byte>?> RequestHighSpeedPermission(ToolPresentNotifier notifier)
         {
+            // This is a broadcast exchange: every module on the bus may answer, and a single
+            // refusal must abort the switch. It deliberately drives the device directly rather
+            // than through Query<T>, because Query<T> installs an inbound filter that keeps only
+            // replies from the one module it addressed. That filter would discard the other
+            // modules' grant/refuse responses we specifically need to collect here.
             Message permissionCheck = this.protocol.CreateHighSpeedPermissionRequest(DeviceId.Broadcast);
             await this.device.SendMessage(permissionCheck);
 

--- a/Apps/PcmLibrary/Vehicle.Logging.cs
+++ b/Apps/PcmLibrary/Vehicle.Logging.cs
@@ -215,6 +215,12 @@ namespace PcmHacking
         /// <summary>
         /// Read a dpid response from the PCM.
         /// </summary>
+        /// <remarks>
+        /// Intentionally not wrapped in an inbound filter: this consumes a continuous DPID
+        /// data stream that an earlier RequestDpids set running, so there is no paired request
+        /// here to derive a filter from, and filtering a stream could drop log rows. Like the
+        /// recovery-mode listens, it stays unfiltered.
+        /// </remarks>
         public async Task<RawLogData?> ReadLogData()
         {
             Message message;
@@ -259,13 +265,19 @@ namespace PcmHacking
                 return Response.Create(ResponseStatus.Error, 0);
             }
 
-            Message responseMessage = await this.ReceiveMessage();
-            if (responseMessage == null)
+            // Single-target request/response, so filter to the PCM's reply: only one receive
+            // happens here, so dropping off-conversation traffic at the device keeps that one
+            // read from grabbing unrelated bus noise.
+            using (this.device.FilterInbound(MessageFilters.RepliesFrom(request)))
             {
-                return Response.Create(ResponseStatus.Error, 0);
-            }
+                Message responseMessage = await this.ReceiveMessage();
+                if (responseMessage == null)
+                {
+                    return Response.Create(ResponseStatus.Error, 0);
+                }
 
-            return this.protocol.ParsePidResponse(responseMessage);
+                return this.protocol.ParsePidResponse(responseMessage);
+            }
         }
 
         public async Task<Response<uint>> GetRam(int address)

--- a/Apps/PcmLibrary/Vehicle.Properties.cs
+++ b/Apps/PcmLibrary/Vehicle.Properties.cs
@@ -22,44 +22,14 @@ namespace PcmHacking
         /// </summary>
         public async Task<Response<string>> QueryVin()
         {
-            await this.device.SetTimeout(TimeoutScenario.ReadProperty);
-
-            this.device.ClearMessageQueue();
-
-            if (!await this.device.SendMessage(this.protocol.CreateVinRequest1()))
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. Request for block 1 failed.");
-            }
-
-            Message response1 = await this.device.ReceiveMessage();
-            if (response1 == null)
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. No response to request for block 1.");
-            }
-
-            if (!await this.device.SendMessage(this.protocol.CreateVinRequest2()))
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. Request for block 2 failed.");
-            }
-
-            Message response2 = await this.device.ReceiveMessage();
-            if (response2 == null)
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. No response to request for block 2.");
-            }
-
-            if (!await this.device.SendMessage(this.protocol.CreateVinRequest3()))
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. Request for block 3 failed.");
-            }
-
-            Message response3 = await this.device.ReceiveMessage();
-            if (response3 == null)
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. No response to request for block 3.");
-            }
-
-            return this.protocol.ParseVinResponses(response1.GetBytes(), response2.GetBytes(), response3.GetBytes());
+            return await this.ReadBlockSequence(
+                new Func<Message>[]
+                {
+                    this.protocol.CreateVinRequest1,
+                    this.protocol.CreateVinRequest2,
+                    this.protocol.CreateVinRequest3,
+                },
+                r => this.protocol.ParseVinResponses(r[0].GetBytes(), r[1].GetBytes(), r[2].GetBytes()));
         }
 
         /// <summary>
@@ -67,44 +37,14 @@ namespace PcmHacking
         /// </summary>
         public async Task<Response<string>> QuerySerial()
         {
-            await this.device.SetTimeout(TimeoutScenario.ReadProperty);
-
-            this.device.ClearMessageQueue();
-
-            if (!await this.device.SendMessage(this.protocol.CreateSerialRequest1()))
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. Request for block 1 failed.");
-            }
-
-            Message response1 = await this.device.ReceiveMessage();
-            if (response1 == null)
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. No response to request for block 1.");
-            }
-
-            if (!await this.device.SendMessage(this.protocol.CreateSerialRequest2()))
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. Request for block 2 failed.");
-            }
-
-            Message response2 = await this.device.ReceiveMessage();
-            if (response2 == null)
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. No response to request for block 2.");
-            }
-
-            if (!await this.device.SendMessage(this.protocol.CreateSerialRequest3()))
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. Request for block 3 failed.");
-            }
-
-            Message response3 = await this.device.ReceiveMessage();
-            if (response3 == null)
-            {
-                return Response.Create(ResponseStatus.Timeout, "Unknown. No response to request for block 3.");
-            }
-
-            return this.protocol.ParseSerialResponses(response1, response2, response3);
+            return await this.ReadBlockSequence(
+                new Func<Message>[]
+                {
+                    this.protocol.CreateSerialRequest1,
+                    this.protocol.CreateSerialRequest2,
+                    this.protocol.CreateSerialRequest3,
+                },
+                r => this.protocol.ParseSerialResponses(r[0], r[1], r[2]));
         }
 
         /// <summary>
@@ -253,6 +193,51 @@ namespace PcmHacking
 
             var query = this.CreateQuery(generator, this.protocol.ParseUInt32FromBlockReadResponse, cancellationToken);
             return await query.Execute();
+        }
+
+        /// <summary>
+        /// Helper for properties the PCM returns as a fixed sequence of VPW blocks (VIN and
+        /// serial are each three blocks). Sends each block request in turn, collects the
+        /// replies under a single inbound-filter scope, then hands the raw responses to the
+        /// caller's parser.
+        /// </summary>
+        /// <remarks>
+        /// This multi-block shape is VPW-specific: on CAN the same data is a single
+        /// ReadDataByIdentifier, so this stays a VPW-local helper rather than a cross-protocol
+        /// abstraction. The CAN path fans out separately at the command layer.
+        /// </remarks>
+        private async Task<Response<string>> ReadBlockSequence(
+            Func<Message>[] requestFactories,
+            Func<Message[], Response<string>> parse)
+        {
+            await this.device.SetTimeout(TimeoutScenario.ReadProperty);
+            this.device.ClearMessageQueue();
+
+            Message[] responses = new Message[requestFactories.Length];
+            Message first = requestFactories[0]();
+
+            // The whole sequence is one logical read from the PCM, so filter to its replies
+            // for the duration. All blocks target the same module, so the first request's
+            // predicate covers them all.
+            using (this.device.FilterInbound(MessageFilters.RepliesFrom(first)))
+            {
+                for (int i = 0; i < requestFactories.Length; i++)
+                {
+                    Message request = (i == 0) ? first : requestFactories[i]();
+                    if (!await this.device.SendMessage(request))
+                    {
+                        return Response.Create(ResponseStatus.Timeout, $"Unknown. Request for block {i + 1} failed.");
+                    }
+
+                    responses[i] = await this.device.ReceiveMessage();
+                    if (responses[i] == null)
+                    {
+                        return Response.Create(ResponseStatus.Timeout, $"Unknown. No response to request for block {i + 1}.");
+                    }
+                }
+            }
+
+            return parse(responses);
         }
     }
 }

--- a/Apps/PcmLibrary/Vehicle.TestKernel.cs
+++ b/Apps/PcmLibrary/Vehicle.TestKernel.cs
@@ -184,6 +184,8 @@ namespace PcmHacking
                 // its time caculating CRCs rather than responding to messages.
                 int retryDelay = 1500;
                 Message query = this.protocol.CreateCrcQuery(range.Address, range.Size);
+                using (this.device.FilterInbound(MessageFilters.RepliesFrom(query)))
+                {
                 for (int attempts = 0; attempts < 100; attempts++)
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -215,6 +217,7 @@ namespace PcmHacking
                     crc = crcResponse.Value;
                     break;
                 }
+                } // using (FilterInbound)
 
                 this.device.ClearMessageQueue();
 
@@ -340,7 +343,7 @@ namespace PcmHacking
                         continue;
                     }
 
-                    if (await this.WaitForSuccess(this.protocol.ParseUploadResponse, cancellationToken))
+                    if (await this.WaitForSuccess(this.protocol.ParseUploadResponse, cancellationToken, request: blockMessage))
                     {
                         break;
                     }

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -263,6 +263,11 @@ namespace PcmHacking
         }
 
 
+        // TODO (message filtering, 1c): verify recovery-mode detection still works with
+        // inbound filtering active. These listens have no preceding request to derive a
+        // filter from and run directly on the device (not via Query<T>), so they should be
+        // unaffected — but confirm on hardware that an unsolicited recovery broadcast is
+        // still seen once the filter feature is in use.
         public async Task<Response<bool>> CheckForRecoveryMode(CancellationToken cancellationToken)
         {
             bool result = await this.device.IsCommandBroadcasting(0xA2);
@@ -309,6 +314,15 @@ namespace PcmHacking
             await this.device.SetTimeout(TimeoutScenario.ReadProperty);
 
             Message seedRequest = this.protocol.CreateSeedRequest();
+
+            // Seed and key are both Tool<->PCM exchanges, so one inbound filter (replies from
+            // the PCM, addressed to the tool) covers the whole unlock. The scope spans every
+            // seed re-request and security-delay wait, and is released the moment this method
+            // returns (success, denial, or give-up) so a failed/aborted unlock leaves no filter
+            // behind. The brute-force tool has its own bespoke seed/key loop in BruteForcer and
+            // is intentionally left unfiltered.
+            using (this.device.FilterInbound(MessageFilters.RepliesFrom(seedRequest)))
+            {
 
             // The PCM permits a couple of key attempts and then forces a time delay before each
             // further attempt. A wrong key or an outright denial will never succeed, so we fail fast on
@@ -512,6 +526,7 @@ namespace PcmHacking
 
             logger.AddUserMessage("Unable to process unlock response.");
             return false;
+            } // using (FilterInbound)
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -252,6 +252,18 @@ namespace PcmHacking
                 this.notifier);
         }
 
+        /// <summary>
+        /// Open an inbound message-filter scope for a request/response exchange driven
+        /// through this Vehicle (e.g. the CKernel* read/verify loops, which don't hold a
+        /// direct Device reference). While the returned scope is held, bus traffic that
+        /// isn't a reply to the given request is dropped; dispose it when the exchange is
+        /// done. Mirrors how the Query class filters its own exchanges.
+        /// </summary>
+        public IDisposable FilterRepliesTo(Message request)
+        {
+            return this.device.FilterInbound(MessageFilters.RepliesFrom(request));
+        }
+
         public async Task<bool> SendMessage(Message message)
         {
             return await this.device.SendMessage(message);
@@ -578,31 +590,40 @@ namespace PcmHacking
         /// <summary>
         /// Read messages from the device, ignoring irrelevant messages.
         /// </summary>
-        private async Task<bool> WaitForSuccess(Func<Message, Response<bool>> filter, CancellationToken cancellationToken, int attempts = MaxReceiveAttempts)
+        private async Task<bool> WaitForSuccess(Func<Message, Response<bool>> filter, CancellationToken cancellationToken, int attempts = MaxReceiveAttempts, Message? request = null)
         {
-            for (int attempt = 1; attempt <= attempts; attempt++)
+            // When the caller passes the request it just sent (e.g. a flash-write block), filter
+            // inbound traffic to replies from that module for the duration of this wait. Callers
+            // that don't (legacy) get the previous unfiltered behavior.
+            IDisposable? filterScope = request != null
+                ? this.device.FilterInbound(MessageFilters.RepliesFrom(request))
+                : null;
+            using (filterScope)
             {
-                if (cancellationToken.IsCancellationRequested)
+                for (int attempt = 1; attempt <= attempts; attempt++)
                 {
-                    break;
-                }
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
 
-                Message message = await this.device.ReceiveMessage();
-                if (message == null)
-                {
-                    await this.SendToolPresentNotification();
-                    continue;
-                }
+                    Message message = await this.device.ReceiveMessage();
+                    if (message == null)
+                    {
+                        await this.SendToolPresentNotification();
+                        continue;
+                    }
 
-                Response<bool> response = filter(message);
-                if ((response.Status != ResponseStatus.Success) && (response.Status != ResponseStatus.Refused))
-                {
-                    logger.AddDebugMessage("Ignoring message: " + response.Status + "  " + message.ToString());
-                    continue;
-                }
+                    Response<bool> response = filter(message);
+                    if ((response.Status != ResponseStatus.Success) && (response.Status != ResponseStatus.Refused))
+                    {
+                        logger.AddDebugMessage("Ignoring message: " + response.Status + "  " + message.ToString());
+                        continue;
+                    }
 
-                logger.AddDebugMessage("Found response, " + response.Status);
-                return response.Value;
+                    logger.AddDebugMessage("Found response, " + response.Status);
+                    return response.Value;
+                }
             }
 
             return false;
@@ -625,30 +646,36 @@ namespace PcmHacking
             }
 
             ResponseStatus lastStatus = ResponseStatus.Error;
-            for (int receiveAttempt = 1; receiveAttempt <= MaxReceiveAttempts; receiveAttempt++)
+            // Filter the read payload to replies from the PCM we addressed. This is the bulk,
+            // highest-volume loop, so on an in-car (noisy) bus it benefits most from dropping
+            // off-conversation traffic before it eats into the receive budget.
+            using (this.device.FilterInbound(MessageFilters.RepliesFrom(message)))
             {
-                if (cancellationToken.IsCancellationRequested)
+                for (int receiveAttempt = 1; receiveAttempt <= MaxReceiveAttempts; receiveAttempt++)
                 {
-                    return Response.Create<byte[]>(ResponseStatus.Cancelled, new byte[0]);
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return Response.Create<byte[]>(ResponseStatus.Cancelled, new byte[0]);
+                    }
+
+                    Message payloadMessage = await this.device.ReceiveMessage();
+                    if (payloadMessage == null)
+                    {
+                        logger.AddDebugMessage("No payload following read request.");
+                        continue;
+                    }
+
+                    logger.AddDebugMessage("Processing message");
+
+                    Response<byte[]> payloadResponse = messageParser(payloadMessage);
+                    if (payloadResponse.Status == ResponseStatus.Success)
+                    {
+                        return payloadResponse;
+                    }
+
+                    lastStatus = payloadResponse.Status;
+                    logger.AddDebugMessage("Unable to process response: " + lastStatus + " " + payloadMessage.ToString());
                 }
-
-                Message payloadMessage = await this.device.ReceiveMessage();
-                if (payloadMessage == null)
-                {
-                    logger.AddDebugMessage("No payload following read request.");
-                    continue;
-                }
-
-                logger.AddDebugMessage("Processing message");
-
-                Response<byte[]> payloadResponse = messageParser(payloadMessage);
-                if (payloadResponse.Status == ResponseStatus.Success)
-                {
-                    return payloadResponse;
-                }
-
-                lastStatus = payloadResponse.Status;
-                logger.AddDebugMessage("Unable to process response: " + lastStatus + " " + payloadMessage.ToString());
             }
 
             return Response.Create<byte[]>(lastStatus, new byte[0]);

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
@@ -76,7 +76,7 @@ namespace PcmHacking
 
         public override string ToString()
         {
-            string deviceName = this.J2534Port.LoadedDevice?.Name;
+            string? deviceName = this.J2534Port.LoadedDevice?.Name;
             return string.IsNullOrEmpty(deviceName)
                 ? "J2534 Device"
                 : "J2534 " + deviceName;


### PR DESCRIPTION
Adds filtering to the comms paths, to improve function in car reliability with potentially chatty modules. Tested no regression in PCM Hammer versions on the bench with J2534 and AVT. Need someone to test obdlink. It's possible that its transaction based protocol may give up before the right packet comes in. Having said that, it would have failed in this scenareo anyway without the filtering just the same.