### PR TITLE
Antus/p08 16259686

### DIFF
--- a/.github/workflows/CheckBuild.yml
+++ b/.github/workflows/CheckBuild.yml
@@ -9,6 +9,8 @@
 # 2026-04-07 - Antus <pcmhacking.net> Update dependencies
 # 2026-04-10 - Antus <pcmhacking.net> Update for WinForms + Uno Windows + Uno Android
 # 2026-06-18 - Antus <pcmhacking.net> E38 PPC Kernel, via source or binary distribution
+# 2026-08-11 - Antus <pcmhacking.net> Delete the temp kernels artifact in its own job, after
+#                                     all consumers, instead of racing them from Applications
 #
 
 name: CheckBuild
@@ -377,25 +379,6 @@ jobs:
         name: Temp_Kernels_${{github.sha}}
         path: TemporaryArtifactStorage/Kernels
 
-    - name: Remove temporary kernels artifact
-      if: always()
-      uses: actions/github-script@v8
-      with:
-        script: |
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
-          const run_id = context.runId;
-          const targetName = `Temp_Kernels_${context.sha}`;
-          const artifacts = await github.paginate(
-            github.rest.actions.listWorkflowRunArtifacts,
-            { owner, repo, run_id, per_page: 100 }
-          );
-          const matches = artifacts.filter(a => a.name === targetName);
-          for (const artifact of matches) {
-            core.info(`Deleting temporary artifact ${artifact.name} (${artifact.id})`);
-            await github.rest.actions.deleteArtifact({ owner, repo, artifact_id: artifact.id });
-          }
-
     - name: Inject kernels into Uno assets
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       shell: pwsh
@@ -690,3 +673,43 @@ jobs:
             --generate-notes
         }
         if ($LASTEXITCODE -ne 0) { throw "gh release step failed (exit $LASTEXITCODE)" }
+
+  # Temp_Kernels_<sha> is an intermediate handoff from the Kernels job, consumed by every
+  # job that needs the kernels; it is not something anyone should download from the run
+  # summary, so it is deleted once it is no longer needed. That deletion lives here, in a
+  # job gated on ALL of its consumers, rather than inside a consumer: the consumers run in
+  # parallel, so a consumer that deleted the shared artifact would race the others and
+  # intermittently break whichever one had not downloaded it yet.
+  #
+  # Any future job that downloads Temp_Kernels_<sha> must be added to "needs" below.
+  #
+  # always() so the artifact is still cleaned up when a consumer fails or is cancelled.
+  # This job deliberately does not fail the run - a leftover temp artifact expires on its
+  # own and is not worth turning a good build red over.
+  CleanupKernelsArtifact:
+    needs: [ Kernels, LinuxCLI, Applications ]
+    if: always()
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Remove temporary kernels artifact
+      continue-on-error: true
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const run_id = context.runId;
+          const targetName = `Temp_Kernels_${context.sha}`;
+          const artifacts = await github.paginate(
+            github.rest.actions.listWorkflowRunArtifacts,
+            { owner, repo, run_id, per_page: 100 }
+          );
+          const matches = artifacts.filter(a => a.name === targetName);
+          if (matches.length === 0) {
+            core.info(`No artifact named ${targetName} to delete.`);
+          }
+          for (const artifact of matches) {
+            core.info(`Deleting temporary artifact ${artifact.name} (${artifact.id})`);
+            await github.rest.actions.deleteArtifact({ owner, repo, artifact_id: artifact.id });
+          }

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -1402,7 +1402,6 @@ namespace PcmHacking
                 case 16259676:
                 case 16259677:
                 case 16259682:
-                case 16259686:
                 case 16259687:
                 case 16259688:
                 case 16259694:
@@ -3205,6 +3204,7 @@ namespace PcmHacking
                 case 12225345: // https://pcmhacking.net/forums/viewtopic.php?p=136159#p136159 2000 Cavalier 2.2 manual
                 case 12225346: // https://pcmhacking.net/forums/viewtopic.php?p=136159#p136159 2000 Cavalier 2.2 manual
                 case 16257436:
+                case 16259686:
                     PCMInfo(PcmType.P08);
                     this.Description = "P08 Service No 9356249";
                     this.ServiceNumber = 9356249;


### PR DESCRIPTION
Fix race condition noticed after the OSID change.

Linux and Windows builds require different runners, both use the same kernels artifact.

Previously the windows build removed the temp artifact, and if Linux ran after it, it would fail.

This change moves the temp kernel artifact cleanup to a later stage gated by the build process for both operating systems.