### PR TITLE
WPF: PHZ document model, operation-state fixes, and CLI de-dup

### DIFF
--- a/Apps/J2534DotNet/J2534DotNet/J2534Detect.cs
+++ b/Apps/J2534DotNet/J2534DotNet/J2534Detect.cs
@@ -1,15 +1,15 @@
-﻿#region Copyright (c) 2010, Michael Kelly
-/* 
+#region Copyright (c) 2010, Michael Kelly
+/*
  * Copyright (c) 2010, Michael Kelly
  * michael.e.kelly@gmail.com
  * http://michael-kelly.com/
- * 
+ *
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
  * Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -21,9 +21,10 @@
  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 #endregion License
+using System;
 using System.Collections.Generic;
 using Microsoft.Win32;
 
@@ -32,45 +33,77 @@ namespace J2534DotNet
     static public class J2534Detect
     {
         private const string PASSTHRU_REGISTRY_PATH = "Software\\PassThruSupport.04.04";
-        private const string PASSTHRU_REGISTRY_PATH_6432 = "Software\\Wow6432Node\\PassThruSupport.04.04";
 
+        /// <summary>
+        /// List every installed J2534 driver, from both registry views.
+        /// </summary>
+        /// <remarks>
+        /// 32-bit and 64-bit drivers register under separate views of the same key, and the registry
+        /// redirects a process to the view matching its own bitness. Reading only that one view hides
+        /// every driver installed with the other bitness - which on a 64-bit process is usually most
+        /// of them, since J2534 drivers are typically 32-bit. The native view is read first so that a
+        /// driver registered in both views is taken from the view whose DLL this process can load.
+        /// </remarks>
         static public List<J2534Device> ListDevices()
         {
             List<J2534Device> j2534Devices = new List<J2534Device>();
-            RegistryKey? myKey = Registry.LocalMachine.OpenSubKey(PASSTHRU_REGISTRY_PATH, false);
-            if (myKey == null)
-            {
-                myKey = Registry.LocalMachine.OpenSubKey(PASSTHRU_REGISTRY_PATH_6432, false);
-                if (myKey == null)
-                    return j2534Devices;
-            }
-            string[] devices = myKey.GetSubKeyNames();
-            foreach (string device in devices)
-            {
-                J2534Device tempDevice = new J2534Device();
-                RegistryKey? deviceKey = myKey.OpenSubKey(device);
-                if(deviceKey == null)
-                    continue;
-                tempDevice.Vendor = deviceKey.GetValue("Vendor", "") as string ?? string.Empty;
-                tempDevice.Name = deviceKey.GetValue("Name", "") as string ?? string.Empty;
-                tempDevice.ConfigApplication = deviceKey.GetValue("ConfigApplication", "") as string ?? string.Empty;
-                tempDevice.FunctionLibrary = deviceKey.GetValue("FunctionLibrary", "") as string ?? string.Empty;
+            HashSet<string> namesSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                tempDevice.CANChannels = (int)(deviceKey.GetValue("CAN", 0) ?? 0);
-                tempDevice.ISO15765Channels = (int)(deviceKey.GetValue("ISO15765", 0) ?? 0);
-                tempDevice.J1850PWMChannels = (int)(deviceKey.GetValue("J1850PWM", 0) ?? 0);
-                tempDevice.J1850VPWChannels = (int)(deviceKey.GetValue("J1850VPW", 0) ?? 0);
-                tempDevice.ISO9141Channels = (int)(deviceKey.GetValue("ISO9141", 0) ?? 0);
-                tempDevice.ISO14230Channels = (int)(deviceKey.GetValue("ISO14230", 0) ?? 0);
-                tempDevice.SCI_A_ENGINEChannels = (int)(deviceKey.GetValue("SCI_A_ENGINE", 0) ?? 0);
-                tempDevice.SCI_A_TRANSChannels = (int)(deviceKey.GetValue("SCI_A_TRANS", 0) ?? 0);
-                tempDevice.SCI_B_ENGINEChannels = (int)(deviceKey.GetValue("SCI_B_ENGINE", 0) ?? 0);
-                tempDevice.SCI_B_TRANSChannels = (int)(deviceKey.GetValue("SCI_B_TRANS", 0) ?? 0);
+            RegistryView nativeView = Environment.Is64BitProcess ? RegistryView.Registry64 : RegistryView.Registry32;
+            RegistryView otherView = Environment.Is64BitProcess ? RegistryView.Registry32 : RegistryView.Registry64;
 
-                j2534Devices.Add(tempDevice);
-            }
+            AddDevicesFromView(j2534Devices, namesSeen, nativeView);
+            AddDevicesFromView(j2534Devices, namesSeen, otherView);
 
             return j2534Devices;
+        }
+
+        /// <summary>
+        /// Append the drivers registered in one registry view, skipping names already listed.
+        /// </summary>
+        private static void AddDevicesFromView(List<J2534Device> j2534Devices, HashSet<string> namesSeen, RegistryView view)
+        {
+            using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view))
+            using (RegistryKey? myKey = baseKey.OpenSubKey(PASSTHRU_REGISTRY_PATH, false))
+            {
+                if (myKey == null)
+                {
+                    return;
+                }
+
+                foreach (string device in myKey.GetSubKeyNames())
+                {
+                    using (RegistryKey? deviceKey = myKey.OpenSubKey(device))
+                    {
+                        if (deviceKey == null)
+                            continue;
+
+                        J2534Device tempDevice = new J2534Device();
+                        tempDevice.Vendor = deviceKey.GetValue("Vendor", "") as string ?? string.Empty;
+                        tempDevice.Name = deviceKey.GetValue("Name", "") as string ?? string.Empty;
+                        tempDevice.ConfigApplication = deviceKey.GetValue("ConfigApplication", "") as string ?? string.Empty;
+                        tempDevice.FunctionLibrary = deviceKey.GetValue("FunctionLibrary", "") as string ?? string.Empty;
+
+                        tempDevice.CANChannels = (int)(deviceKey.GetValue("CAN", 0) ?? 0);
+                        tempDevice.ISO15765Channels = (int)(deviceKey.GetValue("ISO15765", 0) ?? 0);
+                        tempDevice.J1850PWMChannels = (int)(deviceKey.GetValue("J1850PWM", 0) ?? 0);
+                        tempDevice.J1850VPWChannels = (int)(deviceKey.GetValue("J1850VPW", 0) ?? 0);
+                        tempDevice.ISO9141Channels = (int)(deviceKey.GetValue("ISO9141", 0) ?? 0);
+                        tempDevice.ISO14230Channels = (int)(deviceKey.GetValue("ISO14230", 0) ?? 0);
+                        tempDevice.SCI_A_ENGINEChannels = (int)(deviceKey.GetValue("SCI_A_ENGINE", 0) ?? 0);
+                        tempDevice.SCI_A_TRANSChannels = (int)(deviceKey.GetValue("SCI_A_TRANS", 0) ?? 0);
+                        tempDevice.SCI_B_ENGINEChannels = (int)(deviceKey.GetValue("SCI_B_ENGINE", 0) ?? 0);
+                        tempDevice.SCI_B_TRANSChannels = (int)(deviceKey.GetValue("SCI_B_TRANS", 0) ?? 0);
+
+                        // The device is chosen by name elsewhere, so a name listed twice would be
+                        // ambiguous. The native view was read first, so this keeps the loadable one.
+                        if (!namesSeen.Add(tempDevice.Name))
+                            continue;
+
+                        j2534Devices.Add(tempDevice);
+                    }
+                }
+            }
         }
     }
 }

--- a/Apps/PcmLibrary/CanIdentification.cs
+++ b/Apps/PcmLibrary/CanIdentification.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-only
+﻿// SPDX-License-Identifier: GPL-3.0-only
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +21,11 @@ namespace PcmHacking
     {
         private enum Format { Ascii, Uint32 }
 
+        private const byte VinDid = 0x90;
+
+        /// <summary>The display name of the VIN identifier; a caller with its own VIN field filters it out.</summary>
+        public const string VinName = "VIN";
+
         private struct Identifier
         {
             public byte Did;
@@ -31,7 +36,7 @@ namespace PcmHacking
         // Probed in DID order; the output lists whichever answered, in this order.
         private static readonly Identifier[] Identifiers =
         {
-            new Identifier { Did = 0x90, Name = "VIN",                Format = Format.Ascii },
+            new Identifier { Did = VinDid, Name = VinName,                Format = Format.Ascii },
             new Identifier { Did = 0xB4, Name = "Traceability (MTC)", Format = Format.Ascii },
             new Identifier { Did = 0xC1, Name = "SWMI 01",            Format = Format.Uint32 },
             new Identifier { Did = 0xC2, Name = "SWMI 02",            Format = Format.Uint32 },
@@ -44,7 +49,60 @@ namespace PcmHacking
             new Identifier { Did = 0xCB, Name = "End Model P/N",      Format = Format.Uint32 },
         };
 
-        public static async Task<List<string>> Read(CanCommands commands, CancellationToken cancellationToken)
+        /// <summary>
+        /// One identifier the module reported, ready to display: its GMLAN name and the formatted
+        /// value. A SWMI item's value is the part number of one flashed software or calibration
+        /// segment.
+        /// </summary>
+        public class Item
+        {
+            public string Name { get; }
+            public string Value { get; }
+
+            public Item(string name, string value)
+            {
+                this.Name = name;
+                this.Value = value;
+            }
+
+            public override string ToString()
+            {
+                return this.Name + ": " + this.Value;
+            }
+        }
+
+        /// <summary>
+        /// The identification a CAN PCM reported: the values a caller can show in its own fields,
+        /// every identifier that answered, and the whole list already formatted for a log.
+        /// </summary>
+        public class Identity
+        {
+            /// <summary>Operating system id, or zero if no candidate DID answered with a usable one.</summary>
+            public uint Osid { get; }
+
+            /// <summary>VIN, or empty if the module did not report one.</summary>
+            public string Vin { get; }
+
+            /// <summary>Every identifier that answered, in DID order.</summary>
+            public IReadOnlyList<Item> Items { get; }
+
+            /// <summary>The OSID and every identifier that answered, formatted "Name: value".</summary>
+            public IReadOnlyList<string> Lines { get; }
+
+            public Identity(uint osid, string vin, IReadOnlyList<Item> items, IReadOnlyList<string> lines)
+            {
+                this.Osid = osid;
+                this.Vin = vin;
+                this.Items = items;
+                this.Lines = lines;
+            }
+        }
+
+        /// <summary>
+        /// Read every supported identifier and return both the values and their formatted form, so a
+        /// UI with its own fields and a UI that just logs the list share one implementation.
+        /// </summary>
+        public static async Task<Identity> Query(CanCommands commands, CancellationToken cancellationToken)
         {
             // Positive responses only ([0x5A, did, data...]); NRCs are dropped here so the rest of the
             // method never has to test for them.
@@ -67,26 +125,44 @@ namespace PcmHacking
             // candidate that answered with a usable value rather than fixed to one DID. A module that
             // answers but leaves the slot empty (all zeroes or all ones) falls through to the next.
             // Shown on top of the SWMI list because downstream lookups key off it.
+            uint operatingSystemId = 0;
             foreach (byte did in Gmlan.OperatingSystemDids)
             {
                 if (responses.TryGetValue(did, out byte[] osid)
                     && TryGetUint32(osid, out uint osidValue)
                     && Gmlan.IsUsableOsid(osidValue))
                 {
+                    operatingSystemId = osidValue;
                     lines.Add("OSID: " + osidValue);
                     break;
                 }
             }
 
+            string vin = responses.TryGetValue(VinDid, out byte[] vinResponse)
+                ? FormatAscii(vinResponse)
+                : string.Empty;
+
+            List<Item> items = new List<Item>();
             foreach (Identifier id in Identifiers)
             {
                 if (!responses.TryGetValue(id.Did, out byte[] resp)) continue;
                 string value = id.Format == Format.Ascii ? FormatAscii(resp) : FormatUint32(resp);
                 if (value == "0") continue;
-                lines.Add(id.Name + ": " + value);
+                Item item = new Item(id.Name, value);
+                items.Add(item);
+                lines.Add(item.ToString());
             }
 
-            return lines;
+            return new Identity(operatingSystemId, vin, items, lines);
+        }
+
+        /// <summary>
+        /// Read the identification and return just the formatted lines.
+        /// </summary>
+        public static async Task<List<string>> Read(CanCommands commands, CancellationToken cancellationToken)
+        {
+            Identity identity = await Query(commands, cancellationToken);
+            return new List<string>(identity.Lines);
         }
 
         // resp is the full positive response: [0x5A, did, data...].

--- a/Apps/PcmLibrary/Misc/PcmIdentity.cs
+++ b/Apps/PcmLibrary/Misc/PcmIdentity.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using System.Collections.Generic;
+
+namespace PcmHacking
+{
+    /// <summary>
+    /// Everything a "read properties" / "identify" request found about the connected PCM: which bus
+    /// it answered on, its operating system and description, and each property either as a value, as
+    /// not-applicable, or as unavailable. Produced by Vehicle.ReadIdentity so every UI shares one
+    /// implementation of the VPW and CAN identification flows and just displays the result.
+    /// </summary>
+    public class PcmIdentity
+    {
+        /// <summary>Shown for a property the PCM's type does not provide.</summary>
+        public const string NotApplicable = "Not Applicable";
+
+        /// <summary>Shown for a property that applies but did not answer.</summary>
+        public const string Unavailable = "Unavailable";
+
+        /// <summary>The bus the PCM answered on.</summary>
+        public BusProtocol Bus { get; }
+
+        /// <summary>The operating system id, or zero if it could not be read.</summary>
+        public uint Osid { get; }
+
+        /// <summary>The OS description, or <see cref="Unavailable"/>.</summary>
+        public string Description { get; }
+
+        public string Vin { get; }
+        public string CalibrationId { get; }
+        public string HardwareId { get; }
+        public string SerialNumber { get; }
+        public string BroadcastCode { get; }
+        public string Mec { get; }
+        public string Voltage { get; }
+
+        /// <summary>The software module identifiers a CAN PCM reports; empty for a VPW PCM.</summary>
+        public IReadOnlyList<CanIdentification.Item> SoftwareModules { get; }
+
+        /// <summary>
+        /// The whole result formatted for a log, in display order, starting with the bus it was
+        /// found on. A UI can show its own fields and still log this verbatim.
+        /// </summary>
+        public IReadOnlyList<string> Lines { get; }
+
+        public PcmIdentity(
+            BusProtocol bus,
+            uint osid,
+            string description,
+            string vin,
+            string calibrationId,
+            string hardwareId,
+            string serialNumber,
+            string broadcastCode,
+            string mec,
+            string voltage,
+            IReadOnlyList<CanIdentification.Item> softwareModules,
+            IReadOnlyList<string> lines)
+        {
+            this.Bus = bus;
+            this.Osid = osid;
+            this.Description = description;
+            this.Vin = vin;
+            this.CalibrationId = calibrationId;
+            this.HardwareId = hardwareId;
+            this.SerialNumber = serialNumber;
+            this.BroadcastCode = broadcastCode;
+            this.Mec = mec;
+            this.Voltage = voltage;
+            this.SoftwareModules = softwareModules;
+            this.Lines = lines;
+        }
+    }
+}

--- a/Apps/PcmLibrary/Misc/VehicleStatus.cs
+++ b/Apps/PcmLibrary/Misc/VehicleStatus.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-only
+namespace PcmHacking
+{
+    /// <summary>
+    /// What a connection check found: the state the PCM is in, and - when it is running normally -
+    /// the bus it answered on with the properties read from it. Returned by Vehicle.QueryStatus for
+    /// every UI to present in its own way.
+    /// </summary>
+    public class VehicleStatus
+    {
+        /// <summary>The states a connection check can find the PCM in.</summary>
+        public enum State
+        {
+            /// <summary>Running its operating system; Bus, Osid and Voltage are populated.</summary>
+            OperatingSystem,
+
+            /// <summary>Broadcasting a recovery request, so only a write can talk to it.</summary>
+            Recovery,
+
+            /// <summary>Running a kernel from an earlier operation; see KernelVersion.</summary>
+            Kernel,
+        }
+
+        /// <summary>What the PCM is doing.</summary>
+        public State PcmState { get; }
+
+        /// <summary>The bus the PCM answered on.</summary>
+        public BusProtocol Bus { get; }
+
+        /// <summary>The operating system id, or zero when the PCM is in recovery or running a kernel.</summary>
+        public uint Osid { get; }
+
+        /// <summary>The kernel version, or zero when no kernel is running.</summary>
+        public ulong KernelVersion { get; }
+
+        /// <summary>Battery voltage, or empty when the bus in use has no voltage query.</summary>
+        public string Voltage { get; }
+
+        private VehicleStatus(State pcmState, BusProtocol bus, uint osid, ulong kernelVersion, string voltage)
+        {
+            this.PcmState = pcmState;
+            this.Bus = bus;
+            this.Osid = osid;
+            this.KernelVersion = kernelVersion;
+            this.Voltage = voltage;
+        }
+
+        public static VehicleStatus OperatingSystem(BusProtocol bus, uint osid, string voltage)
+        {
+            return new VehicleStatus(State.OperatingSystem, bus, osid, 0, voltage);
+        }
+
+        public static VehicleStatus Recovery()
+        {
+            return new VehicleStatus(State.Recovery, BusProtocol.Vpw, 0, 0, string.Empty);
+        }
+
+        public static VehicleStatus Kernel(ulong kernelVersion)
+        {
+            return new VehicleStatus(State.Kernel, BusProtocol.Vpw, 0, kernelVersion, string.Empty);
+        }
+    }
+}

--- a/Apps/PcmLibrary/Vehicle.Detection.cs
+++ b/Apps/PcmLibrary/Vehicle.Detection.cs
@@ -13,6 +13,50 @@ namespace PcmHacking
         private static readonly BusProtocol[] DetectionBuses = { BusProtocol.Vpw, BusProtocol.Can500k };
 
         /// <summary>
+        /// The bus the PCM was last found on, or null if it has not been found yet.
+        /// </summary>
+        /// <remarks>
+        /// Probed first next time, so a repeated detection (a connection poll, or one operation after
+        /// another) does not pay for a probe of the bus that did not answer last time.
+        /// </remarks>
+        public BusProtocol? LastDetectedBus { get; private set; }
+
+        // Buses this device has already been reported as unable to use. Detection runs repeatedly
+        // (every connection poll), and the same limitation is only worth stating once.
+        private readonly HashSet<BusProtocol> reportedUnusableBuses = new HashSet<BusProtocol>();
+
+        /// <summary>
+        /// Tell the user, once, that the interface cannot reach a bus. A VPW-only interface cannot
+        /// see a CAN PCM at all, which is otherwise indistinguishable from an absent PCM.
+        /// </summary>
+        private void ReportUnusableBus(BusProtocol bus)
+        {
+            if (this.reportedUnusableBuses.Add(bus))
+            {
+                this.logger.AddUserMessage($"This device cannot use the {bus} bus, so a {bus} module cannot be found with it.");
+            }
+        }
+
+        /// <summary>
+        /// The detection buses, with the one that answered last time first.
+        /// </summary>
+        private IEnumerable<BusProtocol> BusesToProbe()
+        {
+            if (this.LastDetectedBus.HasValue)
+            {
+                yield return this.LastDetectedBus.Value;
+            }
+
+            foreach (BusProtocol bus in DetectionBuses)
+            {
+                if (bus != this.LastDetectedBus)
+                {
+                    yield return bus;
+                }
+            }
+        }
+
+        /// <summary>
         /// Scan every bus the device supports, OSID-probing each target, and return the modules that
         /// answer. Leaves the device on the last bus probed; callers that intend to operate should
         /// then select a module (see SelectModule / DetectAndSelectPcm).
@@ -24,7 +68,12 @@ namespace PcmHacking
             foreach (BusProtocol bus in DetectionBuses)
             {
                 if (cancellationToken.IsCancellationRequested) break;
-                if (!await this.device.SetProtocol(bus)) continue;   // device can't do this bus
+                if (!await this.device.SetProtocol(bus))
+                {
+                    this.ReportUnusableBus(bus);
+                    continue;
+                }
+
                 await this.device.SetTimeout(TimeoutScenario.Detect);
 
                 foreach (Target target in DetectionTargets)
@@ -74,10 +123,15 @@ namespace PcmHacking
         public async Task<DetectedModule?> DetectAndSelectPcm(CancellationToken cancellationToken)
         {
             // Stop at the first bus the PCM answers on, so a VPW read is not slowed by a CAN probe.
-            foreach (BusProtocol bus in DetectionBuses)
+            foreach (BusProtocol bus in this.BusesToProbe())
             {
                 if (cancellationToken.IsCancellationRequested) break;
-                if (!await this.device.SetProtocol(bus)) continue;   // device can't do this bus
+                if (!await this.device.SetProtocol(bus))
+                {
+                    this.ReportUnusableBus(bus);
+                    continue;
+                }
+
                 await this.device.SetTimeout(TimeoutScenario.Detect);
 
                 this.SetTarget(Target.Pcm);
@@ -85,11 +139,13 @@ namespace PcmHacking
                 if (osid.Status == ResponseStatus.Success)
                 {
                     DetectedModule pcm = new DetectedModule(bus, Target.Pcm, osid.Value);
+                    this.LastDetectedBus = bus;
                     await this.SelectModule(pcm);
                     return pcm;
                 }
             }
 
+            this.LastDetectedBus = null;
             return null;
         }
 

--- a/Apps/PcmLibrary/Vehicle.Identity.cs
+++ b/Apps/PcmLibrary/Vehicle.Identity.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PcmHacking
+{
+    public partial class Vehicle
+    {
+        /// <summary>
+        /// Detect the PCM, then read and format its identification. Handles both buses: a VPW PCM is
+        /// read with the block-read property queries, a CAN PCM with GMLAN ReadDataByIdentifier. Null
+        /// when no PCM answered. On success the device is left on the PCM's bus.
+        /// </summary>
+        /// <remarks>
+        /// This is the one identification flow, shared by every UI. The VPW branch mirrors the order
+        /// and per-PCM-type gating that the WinForms Identify has always used; the UI only displays
+        /// what is returned (fields, a software-module list, and a ready-to-log line list).
+        /// </remarks>
+        public async Task<PcmIdentity?> ReadIdentity(CancellationToken cancellationToken)
+        {
+            DetectedModule? pcm = await this.DetectAndSelectPcm(cancellationToken);
+            if (pcm == null)
+            {
+                return null;
+            }
+
+            return pcm.Bus == BusProtocol.Can500k
+                ? await this.ReadCanIdentity(pcm, cancellationToken)
+                : await this.ReadVpwIdentity(pcm, cancellationToken);
+        }
+
+        private async Task<PcmIdentity> ReadVpwIdentity(DetectedModule pcm, CancellationToken cancellationToken)
+        {
+            OSIDInfo info = new OSIDInfo(pcm.Osid);
+            PcmType type = info.HardwareType;
+
+            List<string> lines = new List<string>
+            {
+                "Detected PCM on " + pcm.Bus,
+                "OSID: " + pcm.Osid,
+                "Description: " + info.Description,
+            };
+
+            string vin = await ReadProperty(lines, "VIN", true, () => this.QueryVin());
+
+            // Property availability by PCM type, matching the long-standing VPW Identify behavior.
+            string calibrationId = await ReadProperty(lines, "Calibration ID",
+                type != PcmType.BlackBox,
+                () => this.QueryCalibrationId());
+
+            string hardwareId = await ReadProperty(lines, "Hardware ID",
+                type != PcmType.P05 && type != PcmType.P05b && type != PcmType.P10 && type != PcmType.P12 && type != PcmType.E54,
+                () => this.QueryHardwareId());
+
+            string serialNumber = await ReadProperty(lines, "Serial Number",
+                type != PcmType.BlackBox,
+                () => this.QuerySerial());
+
+            string broadcastCode = await ReadProperty(lines, "Broad Cast Code",
+                type != PcmType.P04 && type != PcmType.P04_Early && type != PcmType.P08,
+                () => this.QueryBCC());
+
+            string mec = await ReadProperty(lines, "MEC", true, () => this.QueryMEC());
+            string voltage = await ReadProperty(lines, "Voltage", true, () => this.QueryVoltage());
+
+            return new PcmIdentity(
+                pcm.Bus, pcm.Osid, info.Description,
+                vin, calibrationId, hardwareId, serialNumber, broadcastCode, mec, voltage,
+                Array.Empty<CanIdentification.Item>(),
+                lines);
+        }
+
+        private async Task<PcmIdentity> ReadCanIdentity(DetectedModule pcm, CancellationToken cancellationToken)
+        {
+            CanIdentification.Identity identity = await CanIdentification.Query(this.CreateCanCommands(), cancellationToken);
+
+            List<string> lines = new List<string> { "Detected PCM on " + pcm.Bus, "PCM Identification:" };
+            lines.AddRange(identity.Lines);
+
+            string description = identity.Osid == 0 ? PcmIdentity.Unavailable : new OSIDInfo(identity.Osid).Description;
+            string vin = string.IsNullOrEmpty(identity.Vin) ? PcmIdentity.Unavailable : identity.Vin;
+
+            // The VIN has its own field; the rest of the identifiers are the software module list. The
+            // VPW-only properties do not exist on a CAN PCM.
+            List<CanIdentification.Item> modules = identity.Items
+                .Where(item => item.Name != CanIdentification.VinName)
+                .ToList();
+
+            return new PcmIdentity(
+                pcm.Bus, identity.Osid, description,
+                vin,
+                PcmIdentity.NotApplicable, PcmIdentity.NotApplicable, PcmIdentity.NotApplicable,
+                PcmIdentity.NotApplicable, PcmIdentity.NotApplicable, PcmIdentity.NotApplicable,
+                modules,
+                lines);
+        }
+
+        /// <summary>
+        /// Run one property query, append its log line, and return the display value: the value on
+        /// success, <see cref="PcmIdentity.NotApplicable"/> when the PCM type does not provide it (no
+        /// query run, no line), or <see cref="PcmIdentity.Unavailable"/> when it applied but failed.
+        /// </summary>
+        private static async Task<string> ReadProperty<T>(List<string> lines, string name, bool applicable, Func<Task<Response<T>>> query)
+        {
+            if (!applicable)
+            {
+                return PcmIdentity.NotApplicable;
+            }
+
+            Response<T> response = await query();
+            if (response.Status == ResponseStatus.Success)
+            {
+                string value = response.Value?.ToString() ?? string.Empty;
+                lines.Add(name + ": " + value);
+                return value;
+            }
+
+            lines.Add(name + " query failed: " + response.Status);
+            return PcmIdentity.Unavailable;
+        }
+    }
+}

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -469,7 +469,7 @@ namespace PcmHacking
 
         public async Task<UInt64> GetKernelVersion(int maxRetries = 5)
         {
-            return await this.GetKernelVersion(CancellationToken.None);
+            return await this.GetKernelVersion(CancellationToken.None, maxRetries);
         }
 
         public async Task<UInt64> GetKernelVersion(CancellationToken cancellationToken, int maxRetries = 5)

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -252,7 +252,10 @@ namespace PcmHacking
         /// </remarks>
         public async Task Cleanup()
         {
-            logger.AddDebugMessage("Halting the kernel.");
+            // User-visible (not debug): this is the "back to normal" step every read/write/compare ends
+            // with, so the log shows the kernel was halted and codes cleared. ClearTroubleCodes logs its
+            // own "Clearing trouble codes." line. Mirrors the CAN path's messages.
+            logger.AddUserMessage("Returning PCM to normal mode.");
             await this.ExitKernel();
             await this.ClearTroubleCodes();
         }

--- a/Apps/PcmLibrary/Vehicle.Status.cs
+++ b/Apps/PcmLibrary/Vehicle.Status.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PcmHacking
+{
+    public partial class Vehicle
+    {
+        /// <summary>
+        /// Find out what the PCM is doing: recovery mode, a running kernel, or a normal operating
+        /// system on whichever bus it answers on. Null when nothing answered.
+        /// </summary>
+        /// <remarks>
+        /// This is the shared connection check. It follows the same order as the VPW flow that came
+        /// before it - recovery, then kernel, then identify - with bus detection in place of the
+        /// VPW-only operating system query, so a CAN PCM is found by the same code path. On success
+        /// the device is left on the bus the PCM answered on, ready for normal operations.
+        /// </remarks>
+        public async Task<VehicleStatus?> QueryStatus(CancellationToken cancellationToken)
+        {
+            // Recovery and kernel are VPW-only states, so these two checks only run when the device
+            // is on VPW. They are skipped once the PCM is known to be on CAN, because probing VPW
+            // for states that cannot exist there costs a full timeout on every check.
+            if (this.LastDetectedBus != BusProtocol.Can500k && await this.device.SetProtocol(BusProtocol.Vpw))
+            {
+                this.SetTarget(Target.Pcm);
+
+                Response<bool> recovery = await this.CheckForRecoveryMode(cancellationToken);
+                if (recovery.Status == ResponseStatus.Success && recovery.Value)
+                {
+                    return VehicleStatus.Recovery();
+                }
+
+                ulong kernelVersion = await this.GetKernelVersion(cancellationToken, maxRetries: 1);
+                if (kernelVersion != 0)
+                {
+                    return VehicleStatus.Kernel(kernelVersion);
+                }
+            }
+
+            DetectedModule? pcm = await this.DetectAndSelectPcm(cancellationToken);
+            if (pcm == null)
+            {
+                return null;
+            }
+
+            // Voltage comes from a VPW PID. There is no GMLAN equivalent implemented, so a CAN PCM
+            // reports no voltage rather than a wrong one.
+            string voltage = string.Empty;
+            if (pcm.Bus == BusProtocol.Vpw)
+            {
+                Response<string> response = await this.QueryVoltage();
+                if (response.Status == ResponseStatus.Success)
+                {
+                    voltage = response.Value;
+                }
+            }
+
+            return VehicleStatus.OperatingSystem(pcm.Bus, pcm.Osid, voltage);
+        }
+    }
+}

--- a/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
+++ b/Apps/PcmLibraryWindowsApi/Devices/J2534Device.cs
@@ -190,7 +190,9 @@ namespace PcmHacking
             m2 = LoadLibrary(J2534Port.LoadedDevice);
             if (m2.Status != ResponseStatus.Success)
             {
-                this.Logger.AddUserMessage("Unable to load the J2534 DLL.");
+                // The path is worth showing: a driver registered only for the other bitness is
+                // listed but cannot be loaded, and the Program Files tree it sits in says which.
+                this.Logger.AddUserMessage("Unable to load the J2534 DLL: " + J2534Port.LoadedDevice.FunctionLibrary);
                 return false;
             }
             this.Logger.AddUserMessage("Loaded DLL");
@@ -218,6 +220,15 @@ namespace PcmHacking
                 this.Logger.AddUserMessage("Battery Voltage is: " + volts.Value.ToString());
             }
 
+            // Start on VPW, which is what most of these PCMs use. A CAN-only interface has no VPW
+            // channel to open, so start it on CAN instead of failing initialization outright;
+            // SetProtocol moves either kind of device to the bus an operation needs.
+            if (!this.J2534Port.LoadedDevice.IsJ1850VPWSupported)
+            {
+                this.Logger.AddUserMessage("This device does not support VPW. Initializing on CAN.");
+                return SetProtocolInternal(BusProtocol.Can500k);
+            }
+
             // Set Protocol
             m = ConnectToProtocol(ProtocolID.J1850VPW, BaudRate.J1850VPW_10400, ConnectFlag.NONE);
             if (m.Status != ResponseStatus.Success)
@@ -234,7 +245,7 @@ namespace PcmHacking
                 this.Logger.AddUserMessage("Failed to set filter, J2534 error code: 0x" + m.Value.ToString("X2"));
                 return false;
             }
-           
+
             this.Logger.AddDebugMessage("Device initialization complete.");
 
             return true;
@@ -584,11 +595,42 @@ namespace PcmHacking
             }
         }
 
+        /// <summary>
+        /// Whether the installed driver declares a channel for this bus. CAN is read from the
+        /// ISO15765 channel count, because that is the mode these PCMs are talked to in.
+        /// </summary>
+        private bool SupportsProtocol(BusProtocol protocol)
+        {
+            switch (protocol)
+            {
+                case BusProtocol.Vpw:
+                    return this.J2534Port.LoadedDevice.IsJ1850VPWSupported;
+
+                case BusProtocol.Can500k:
+                    return this.J2534Port.LoadedDevice.IsISO15765Supported;
+
+                default:
+                    return false;
+            }
+        }
+
         private bool SetProtocolInternal(BusProtocol protocol)
         {
-            if (protocol == this.CurrentProtocol)
+            // The open channel has to match, not just the recorded protocol: a failed switch (asking
+            // a VPW-only interface for CAN, say) disconnects the old channel before finding out it
+            // cannot open the new one, which would otherwise leave this claiming to be on a bus whose
+            // channel is closed.
+            if (protocol == this.CurrentProtocol && this.IsProtocolOpen)
             {
                 return true;
+            }
+
+            // The driver declares its channels in the registry, so a bus it does not have is refused
+            // here rather than by disconnecting the working channel and then failing to open the new
+            // one.
+            if (!this.SupportsProtocol(protocol))
+            {
+                return false;
             }
 
             if (protocol == BusProtocol.Can500k)

--- a/Apps/UI/PcmHammerCLI/Program.cs
+++ b/Apps/UI/PcmHammerCLI/Program.cs
@@ -553,96 +553,22 @@ namespace PcmHacking
             return matches.Count == 1 ? matches[0] : null;
         }
 
-        // Mirrors the WinForms "Identify PCM" button. First detects what is on the bus and
-        // selects its protocol (the shared first step of every operation), then reads the rest of
-        // the identification on the selected bus. The OSID comes from detection; VIN, calibration,
-        // hardware ID, serial number, BCC, MEC, and voltage follow over VPW, with the same
-        // hardware-type rules as the WinForms implementation. On CAN the GMLAN DID set is read and
-        // formatted via CanIdentification (VIN, traceability code, OSID, module ids).
+        // The "Identify PCM" operation. One shared flow (Vehicle.ReadIdentity) detects the bus and reads
+        // the identification for both VPW and CAN - the same implementation every UI (WinForms, WPF, Uno)
+        // uses - so the CLI just prints the lines it returns.
         static async Task<bool> IdentifyPcm(Vehicle vehicle, ILogger logger, CancellationToken token)
         {
-            DetectedModule? pcm = await vehicle.DetectAndSelectPcm(token);
-            if (pcm == null)
+            PcmIdentity? identity = await vehicle.ReadIdentity(token);
+            if (identity == null)
             {
                 logger.AddUserMessage("No PCM detected on VPW or CAN.");
                 return false;
             }
 
-            logger.AddUserMessage("Detected PCM on " + pcm.Bus);
-
-            if (pcm.Bus != BusProtocol.Vpw)
+            foreach (string line in identity.Lines)
             {
-                logger.AddUserMessage("PCM Identification:");
-                foreach (string line in await CanIdentification.Read(vehicle.CreateCanCommands(), token))
-                {
-                    logger.AddUserMessage(line);
-                }
-                return true;
+                logger.AddUserMessage(line);
             }
-
-            OSIDInfo pcmInfo = new OSIDInfo(pcm.Osid);
-            logger.AddUserMessage("OSID: " + pcm.Osid);
-            logger.AddUserMessage("Description: " + pcmInfo.Description);
-
-            var vinResponse = await vehicle.QueryVin();
-            if (vinResponse.Status == ResponseStatus.Success)
-                logger.AddUserMessage("VIN: " + vinResponse.Value);
-            else
-                logger.AddUserMessage("VIN query failed: " + vinResponse.Status);
-
-            if (pcmInfo.HardwareType != PcmType.BlackBox)
-            {
-                var calResponse = await vehicle.QueryCalibrationId();
-                if (calResponse.Status == ResponseStatus.Success)
-                    logger.AddUserMessage("Calibration ID: " + calResponse.Value);
-                else
-                    logger.AddUserMessage("Calibration ID query failed: " + calResponse.Status);
-            }
-
-            if (pcmInfo.HardwareType != PcmType.P05 &&
-                pcmInfo.HardwareType != PcmType.P05b &&
-                pcmInfo.HardwareType != PcmType.P10 &&
-                pcmInfo.HardwareType != PcmType.P12 &&
-                pcmInfo.HardwareType != PcmType.E54)
-            {
-                var hwResponse = await vehicle.QueryHardwareId();
-                if (hwResponse.Status == ResponseStatus.Success)
-                    logger.AddUserMessage("Hardware ID: " + hwResponse.Value);
-                else
-                    logger.AddUserMessage("Hardware ID query failed: " + hwResponse.Status);
-            }
-
-            if (pcmInfo.HardwareType != PcmType.BlackBox)
-            {
-                var serialResponse = await vehicle.QuerySerial();
-                if (serialResponse.Status == ResponseStatus.Success)
-                    logger.AddUserMessage("Serial Number: " + serialResponse.Value);
-                else
-                    logger.AddUserMessage("Serial Number query failed: " + serialResponse.Status);
-            }
-
-            if (pcmInfo.HardwareType != PcmType.P04 &&
-                pcmInfo.HardwareType != PcmType.P04_Early &&
-                pcmInfo.HardwareType != PcmType.P08)
-            {
-                var bccResponse = await vehicle.QueryBCC();
-                if (bccResponse.Status == ResponseStatus.Success)
-                    logger.AddUserMessage("Broad Cast Code: " + bccResponse.Value);
-                else
-                    logger.AddUserMessage("BCC query failed: " + bccResponse.Status);
-            }
-
-            var mecResponse = await vehicle.QueryMEC();
-            if (mecResponse.Status == ResponseStatus.Success)
-                logger.AddUserMessage("MEC: " + mecResponse.Value);
-            else
-                logger.AddUserMessage("MEC query failed: " + mecResponse.Status);
-
-            var voltageResponse = await vehicle.QueryVoltage();
-            if (voltageResponse.Status == ResponseStatus.Success)
-                logger.AddUserMessage("Voltage: " + voltageResponse.Value);
-            else
-                logger.AddUserMessage("Voltage query failed: " + voltageResponse.Status);
 
             return true;
         }

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj
@@ -53,6 +53,11 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.1</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.1</TargetPlatformMinVersion>
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86</RuntimeIdentifiers>
+    <!-- Pin the Windows head to a 32-bit apphost so the process can load 32-bit J2534 driver DLLs
+         (a 64-bit process cannot). Without this, an AnyCPU/default build produces a 64-bit apphost;
+         setting the RID here makes 32-bit the default, not only the explicit x86 build. -->
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86</RuntimeIdentifier>
+    <PlatformTarget Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">x86</PlatformTarget>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
   

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/MainModel.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/MainModel.cs
@@ -86,6 +86,8 @@ public partial record MainModel
 
     public IState<string> Voltage => connectionService.Voltage;
 
+    public IState<string> Bus => connectionService.Bus;
+
     /// <summary>
     /// See comments on FrameNavigated above.
     /// </summary>

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/MainPage.xaml
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/MainPage.xaml
@@ -47,6 +47,8 @@
         <TextBlock Grid.Row="1" Grid.Column="6" TextAlignment="Left" VerticalAlignment="Center" HorizontalAlignment="Right" Text="Volts:" Margin="4,0" />
         <TextBlock Grid.Row="1" Grid.Column="7" TextAlignment="Left" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{Binding Voltage}" />
 
+        <TextBlock Grid.Row="1" Grid.Column="8" TextAlignment="Left" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{Binding Bus}" />
+
         <Frame Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="9"
                x:Name="ContentFrame" uen:Region.Attached="True"
                Navigated="{x:Bind FrameNavigated}"/>

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/OtherFunctionsModel.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/OtherFunctionsModel.cs
@@ -24,6 +24,7 @@ public partial record OtherFunctionsModel
 {
     private const string defaultClearCodesButtonText = "Clear Trouble Codes";
     private const string defaultValue = "---";
+
     private readonly DispatcherQueue dispatcherQueue;
     private readonly INavigator navigator;
     private readonly IConnectionService connectionService;
@@ -38,6 +39,12 @@ public partial record OtherFunctionsModel
     public IState<string> SerialNumber => State<string>.Value(this, () => defaultValue);
     public IState<string> BroadcastCode => State<string>.Value(this, () => defaultValue);
     public IState<string> Mec => State<string>.Value(this, () => defaultValue);
+
+    /// <summary>The software module identifiers a CAN PCM reports; empty for a VPW PCM.</summary>
+    public IListState<CanIdentification.Item> SoftwareModules => ListState<CanIdentification.Item>.Empty(this);
+
+    /// <summary>Drives the visibility of the software module list, which only a CAN PCM fills in.</summary>
+    public IState<bool> HasSoftwareModules => State<bool>.Value(this, () => false);
 
     public OtherFunctionsModel(
         INavigator navigator, 
@@ -79,77 +86,40 @@ public partial record OtherFunctionsModel
     [Command]
     private async Task<bool> IdentifyPcm(CancellationToken cancellationToken)
     {
-        const int delay = 50;
         try
         {
             using (ConnectionLease lease = await this.connectionService.BeginActivity("Reading...", true))
             {
                 Vehicle vehicle = lease.Vehicle;
 
-                // All VPW PCMs support the VIN query.
-                await this.Vin.SetAsync(await this.GetVin(vehicle, cancellationToken));
-                await Task.Delay(delay);
-                await this.Mec.SetAsync(await this.GetMec(vehicle, cancellationToken));
-                await Task.Delay(delay);
-
-                // The others depend on the operating system.        
-                const string notApplicable = "Not Applicable";
-                string? osIdString = await this.GetOperatingSystemId(vehicle, cancellationToken);
-                uint osId = (uint)0;
-                if (uint.TryParse(osIdString ?? "", out osId))
+                // One shared flow detects the bus (VPW or CAN) and reads the identification; this
+                // model only displays and logs what it returns.
+                PcmIdentity? identity = await vehicle.ReadIdentity(cancellationToken);
+                if (identity == null)
                 {
-                    OSIDInfo pcmInfo = new OSIDInfo(osId);
-                    await this.Description.SetAsync(pcmInfo.Description);
-                    await Task.Delay(delay);
-
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.BlackBox)
-                    {
-                        await this.CalibrationId.SetAsync(await this.GetCalibrationId(vehicle, cancellationToken));
-                        await Task.Delay(delay);
-                        await this.SerialNumber.SetAsync(await this.GetSerialNumber(vehicle, cancellationToken));
-                        await Task.Delay(delay);
-                    }
-                    else
-                    {
-                        await this.CalibrationId.SetAsync(notApplicable);
-                        await this.SerialNumber.SetAsync(notApplicable);
-                        await Task.Delay(delay);
-                    }
-
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.P10 && pcmInfo.HardwareType != PcmType.P12 && pcmInfo.HardwareType != PcmType.E54)
-                    {
-                        await this.HardwareId.SetAsync(await this.GetHardwareId(vehicle, cancellationToken));
-                        await Task.Delay(delay);
-                    }
-                    else
-                    {
-                        await this.HardwareId.SetAsync(notApplicable);
-                        await Task.Delay(delay);
-                    }
-
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.P04 && pcmInfo.HardwareType != PcmType.P04_Early && pcmInfo.HardwareType != PcmType.P08)
-                    {
-                        await this.BroadcastCode.SetAsync(await this.GetBroadcastCode(vehicle, cancellationToken));
-                        await Task.Delay(delay);
-                    }
-                    else
-                    {
-                        await this.BroadcastCode.SetAsync(notApplicable);
-                        await Task.Delay(delay);
-                    }
-
-                    return true;
-                }
-                else
-                {
-                    string unknown = "Unknown";
-                    await this.Description.SetAsync(unknown);
-                    await this.CalibrationId.SetAsync(unknown);
-                    await this.HardwareId.SetAsync(unknown);
-                    await this.SerialNumber.SetAsync(unknown);
-                    await this.BroadcastCode.SetAsync(unknown);
+                    this.progressLogger.AddUserMessage("No PCM detected.");
                     return false;
                 }
+
+                foreach (string line in identity.Lines)
+                {
+                    this.progressLogger.AddUserMessage(line);
+                }
+
+                await this.Description.SetAsync(identity.Description);
+                await this.Vin.SetAsync(identity.Vin);
+                await this.CalibrationId.SetAsync(identity.CalibrationId);
+                await this.HardwareId.SetAsync(identity.HardwareId);
+                await this.SerialNumber.SetAsync(identity.SerialNumber);
+                await this.BroadcastCode.SetAsync(identity.BroadcastCode);
+                await this.Mec.SetAsync(identity.Mec);
+
+                // Only a CAN PCM reports these; the list is empty (and hidden) for a VPW PCM.
+                ImmutableList<CanIdentification.Item> modules = identity.SoftwareModules.ToImmutableList();
+                await this.SoftwareModules.Update(updater: existing => modules, ct: cancellationToken);
+                await this.HasSoftwareModules.SetAsync(modules.Count > 0);
+
+                return true;
             }
         }
         catch (ConnectionUnavailableException exception)
@@ -163,11 +133,13 @@ public partial record OtherFunctionsModel
             this.progressLogger.AddDebugMessage("Other Functions: Exception while reading properties.");
             this.progressLogger.AddDebugMessage(exception.Message);
             return false;
-        }        
+        }
     }
 
     private async Task ClearDetails()
     {
+        await this.SoftwareModules.Update(updater: existing => ImmutableList<CanIdentification.Item>.Empty, ct: CancellationToken.None);
+        await this.HasSoftwareModules.SetAsync(false);
         await this.CalibrationId.SetAsync(defaultValue);
         await this.SerialNumber.SetAsync(defaultValue);
         await this.HardwareId.SetAsync(defaultValue);
@@ -177,76 +149,6 @@ public partial record OtherFunctionsModel
         await this.HardwareId.SetAsync(defaultValue);
         await this.SerialNumber.SetAsync(defaultValue);
         await this.BroadcastCode.SetAsync(defaultValue);
-    }
-
-    private async ValueTask<string> GetVin(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var vinResponse = await vehicle.QueryVin();
-        if (vinResponse.Status != ResponseStatus.Success)
-        {
-            throw new Exception("VIN query failed: " + vinResponse.Status.ToString());
-        }
-        return vinResponse.Value;
-    }
-
-    private async ValueTask<string> GetOperatingSystemId(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var response = await vehicle.QueryOperatingSystemId(cancellationToken);
-        if (response.Status != ResponseStatus.Success)
-        {
-            throw new Exception("Operating system ID query failed: " + response.Status.ToString());
-        }
-        return response.Value.ToString();
-    }
-
-    private async ValueTask<string> GetCalibrationId(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var response = await vehicle.QueryCalibrationId();
-        if (response.Status != ResponseStatus.Success)
-        {
-            throw new Exception("Calibration ID query failed: " + response.Status.ToString());
-        }
-        return response.Value.ToString();
-    }
-
-    private async ValueTask<string> GetHardwareId(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var response = await vehicle.QueryHardwareId();
-        if (response.Status != ResponseStatus.Success)
-        {
-            throw new Exception("Hardware ID query failed: " + response.Status.ToString());
-        }
-        return response.Value.ToString();
-    }
-
-    private async ValueTask<string> GetSerialNumber(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var response = await vehicle.QuerySerial();
-        if (response.Status != ResponseStatus.Success)
-        {
-            throw new Exception("Serial number query failed: " + response.Status.ToString());
-        }
-        return response.Value.ToString();
-    }
-
-    private async ValueTask<string> GetBroadcastCode(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var response = await vehicle.QueryBCC();
-        if (response.Status != ResponseStatus.Success)
-        {
-            throw new Exception("Broadcast code query failed: " + response.Status.ToString());
-        }
-        return response.Value.ToString();
-    }
-
-    private async ValueTask<string> GetMec(Vehicle vehicle, CancellationToken cancellationToken)
-    {
-        var response = await vehicle.QueryMEC();
-        if (response.Status != ResponseStatus.Success)
-        {
-            throw new Exception("MEC query failed: " + response.Status.ToString());
-        }
-        return response.Value.ToString();
     }
 
     public async Task GoToRead()

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/OtherFunctionsPage.xaml
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/OtherFunctionsPage.xaml
@@ -18,6 +18,7 @@
             <RowDefinition Height="1*" />
             <RowDefinition Height="1*" />
             <RowDefinition Height="1*" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="5*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -116,7 +117,42 @@
         HorizontalAlignment="Left"
         VerticalAlignment="Center" />
 
-        <Grid Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2">
+        <StackPanel
+        Grid.Row="7"
+        Grid.Column="0"
+        Grid.ColumnSpan="2"
+        Visibility="{Binding HasSoftwareModules}">
+            <TextBlock
+            Text="Software Module Identifiers (SWMI)"
+            Margin="0,10,0,4"
+            FontWeight="SemiBold" />
+            <ScrollViewer MaxHeight="200" VerticalScrollBarVisibility="Auto">
+                <ItemsControl ItemsSource="{Binding SoftwareModules}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*" />
+                                    <ColumnDefinition Width="1*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock
+                                Text="{Binding Name}"
+                                Grid.Column="0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center" />
+                                <TextBlock
+                                Text="{Binding Value}"
+                                Grid.Column="1"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center" />
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </StackPanel>
+
+        <Grid Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="1*" />
                 <RowDefinition Height="1*" />

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/SettingsModel.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/SettingsModel.cs
@@ -40,6 +40,33 @@ public class SerialPortListing
     }
 }
 
+/// <summary>
+/// A J2534 interface as offered in the settings list. The name is what identifies the driver;
+/// the display name adds the buses it supports, so a VPW-only interface is visibly unable to
+/// reach a CAN PCM before the user tries it.
+/// </summary>
+public class J2534DeviceListing
+{
+    public string? DisplayName { get; set; }
+    public string? Name { get; set; }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is J2534DeviceListing listing &&
+               Name == listing.Name;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name);
+    }
+
+    public override string ToString()
+    {
+        return DisplayName ?? string.Empty;
+    }
+}
+
 public partial record SettingsModel
 {
     private readonly LoggerAdapter progressLogger;
@@ -63,7 +90,7 @@ public partial record SettingsModel
 
     public IListFeed<string> DeviceCategories => ListFeed<string>.Async(ct => this.GetDeviceCategories(ct)).Selection(SelectedDeviceType);
     public IListFeed<string> BTDevices => ListFeed<string>.Async(ct => this.GetBluetoothDevices(ct)).Selection(SelectedBluetoothDevice);
-    public IListFeed<string> JDevices => ListFeed<string>.Async(ct => this.GetJDevices(ct)).Selection(SelectedJDevice);
+    public IListFeed<J2534DeviceListing> JDevices => ListFeed.Async(ct => this.GetJDevices(ct)).Selection(SelectedJDevice);
     public IListFeed<SerialPortListing> Obd2Ports => ListFeed.Async(ct => this.GetPortNames(ct)).Selection(SelectedObd2Port);
     public IListFeed<SerialPortListing> CanPorts => ListFeed.Async(ct => this.GetPortNames(ct)).Selection(SelectedCanPort);
     
@@ -90,8 +117,8 @@ public partial record SettingsModel
     public IState<SerialPortListing> SelectedCanPort => State<SerialPortListing>
         .Async(this, ct => ValueTask.FromResult(settingsService.GetCanSerialPortName()))
         .ForEach(this.ConnectionSettingsChanged);
-    public IState<string> SelectedJDevice => State<string>
-        .Async(this, ct => ValueTask.FromResult(settingsService.GetJ2534DeviceName()))
+    public IState<J2534DeviceListing> SelectedJDevice => State<J2534DeviceListing>
+        .Async(this, ct => ValueTask.FromResult(settingsService.GetJ2534Device()))
         .ForEach(this.ConnectionSettingsChanged);
     public IState<string> SelectedBluetoothDevice => State<string>
         .Async(this, ct => ValueTask.FromResult(settingsService.GetBluetoothDeviceName()))
@@ -150,19 +177,40 @@ public partial record SettingsModel
         return ValueTask.FromResult(res);
     }
 
-    private ValueTask<IImmutableList<string>> GetJDevices(CancellationToken ct)
+    private ValueTask<IImmutableList<J2534DeviceListing>> GetJDevices(CancellationToken ct)
     {
-        List<string> jDevices = [];
+        List<J2534DeviceListing> jDevices = [];
 #if WINDOWS
         foreach (J2534DotNet.J2534Device device in J2534DeviceFinder.FindInstalledJ2534DLLs(this.progressLogger))
         {
-            jDevices.Add(device.Name);
+            jDevices.Add(new J2534DeviceListing
+            {
+                DisplayName = DescribeJDevice(device),
+                Name = device.Name
+            });
         }
 #endif
-        IImmutableList<string> res = ImmutableList.CreateRange(jDevices);
+        IImmutableList<J2534DeviceListing> res = ImmutableList.CreateRange(jDevices);
         return ValueTask.FromResult(res);
 
     }
+
+#if WINDOWS
+    /// <summary>
+    /// The interface name followed by the buses PCM Hammer can use it on. The driver reports the
+    /// others (ISO9141, SCI, ...) too, but none of them reach a PCM, so they are left out.
+    /// </summary>
+    private static string DescribeJDevice(J2534DotNet.J2534Device device)
+    {
+        List<string> buses = [];
+        if (device.IsJ1850VPWSupported) buses.Add("VPW");
+        if (device.IsISO15765Supported) buses.Add("CAN");
+
+        return buses.Count == 0
+            ? device.Name + " (no usable bus)"
+            : device.Name + " (" + string.Join(", ", buses) + ")";
+    }
+#endif
 
     private ValueTask<bool> AreEqual(string value1, string value2)
     {
@@ -182,7 +230,7 @@ public partial record SettingsModel
         string deviceCategory = await SelectedDeviceType.Value() ?? string.Empty;
         string? portName =
             deviceCategory == DeviceConstants.DeviceCategorySerial ? (await SelectedObd2Port.Value())?.PortName :
-            deviceCategory == DeviceConstants.DeviceCategoryJ2534 ? await SelectedJDevice.Value() :
+            deviceCategory == DeviceConstants.DeviceCategoryJ2534 ? (await SelectedJDevice.Value())?.Name :
             deviceCategory == DeviceConstants.DeviceCategoryBT ? await SelectedBluetoothDevice.Value() : string.Empty;
 
 

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/ConnectionService.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/ConnectionService.cs
@@ -102,6 +102,7 @@ public interface IConnectionService
     IState<string> Activity { get; }
     IState<string> ConnectionError { get; }
     IState<string> OperatingSystemId { get; }
+    IState<string> Bus { get; }
     IState<string> Voltage { get; }
     int ResetTimeRemaining { get; }
 
@@ -120,6 +121,11 @@ public class ConnectionService : IConnectionService
 
     // Slow retry is used when app is idle.
     private const int SlowRetryPeriod = 1000;
+
+    // A first connection has to find the PCM, which can mean probing VPW and then CAN before
+    // anything answers. Once it has been found the bus is known, so a routine poll is quick again.
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(3);
 
     private readonly ISettingsService settingsService;
     private readonly LoggerAdapter logger;
@@ -144,6 +150,7 @@ public class ConnectionService : IConnectionService
     public IState<string> Activity => State.Value(this, () => string.Empty);
     public IState<string> ConnectionError => State.Value(this, () => string.Empty);
     public IState<string> OperatingSystemId => State.Value(this, () => string.Empty);
+    public IState<string> Bus => State.Value(this, () => string.Empty);
     public IState<string> Voltage => State.Value(this, () => string.Empty);
 
     public ConnectionService(
@@ -199,7 +206,7 @@ public class ConnectionService : IConnectionService
             }
             await DeviceState.SetAsync("Connected");
 
-            if (await this.TryPollOnce(newVehicle))
+            if (await this.TryPollOnce(newVehicle, ConnectTimeout))
             {
                 logger.AddUserMessage("PCM Hammer");
 #if !ANDROID
@@ -645,7 +652,7 @@ public class ConnectionService : IConnectionService
                     return;
                 }
 
-                bool success = await this.TryPollOnce(acquiredVehicle);
+                bool success = await this.TryPollOnce(acquiredVehicle, PollTimeout);
                 if (!success)
                 {
                     this.internalState = ConnectionStates.NotConnected;
@@ -685,7 +692,7 @@ public class ConnectionService : IConnectionService
         }
     }
 
-    private async Task<bool> TryPollOnce(Vehicle vehicle)
+    private async Task<bool> TryPollOnce(Vehicle vehicle, TimeSpan timeout)
     {
         bool success = false;
 
@@ -699,7 +706,7 @@ public class ConnectionService : IConnectionService
                 }
                 success = await TimeoutUtilities.TaskWithTimeoutAndException(
                     this.TryRequestVehicleInfo(vehicle, source.Token),
-                    TimeSpan.FromSeconds(3));
+                    timeout);
             }
             catch (TimeoutException)
             {
@@ -748,45 +755,34 @@ public class ConnectionService : IConnectionService
             {
                 await this.OperatingSystemId.SetAsync(string.Empty);
             }
-            logger.AddUserMessage("Checking for a recovery message...");
-            Response<bool> recoveryResponse = await vehicle.CheckForRecoveryMode(cancellationToken);
-            if (recoveryResponse.Status == ResponseStatus.Success && recoveryResponse.Value == true)
-            {
-                logger.AddUserMessage("PCM/ECM recovery mode detected!");
-                await this.OperatingSystemId.SetAsync(_recoveryString);
-                return true;
-            }
-            logger.AddUserMessage("No recovery message detected. Checking for live kernel...");
-            ulong ver = await vehicle.GetKernelVersion(maxRetries: 1);
-            if (ver != 0)
-            {
-                logger.AddUserMessage($"Detected kernel version: {Vehicle.FormatKernelVersion(ver)}");
-                await this.OperatingSystemId.SetAsync(_kernelString);
-                return true;
-            }
-            await this.OperatingSystemId.SetAsync(string.Empty);
-            Response<uint> osidResponse = await vehicle.QueryOperatingSystemId(cancellationToken);
-            if (osidResponse.Status == ResponseStatus.Success)
-            {
-                await this.OperatingSystemId.SetAsync(osidResponse.Value.ToString());
-            }
-            else
+
+            // One shared check covers recovery mode, a live kernel, and a normal PCM on whichever
+            // bus it answers on. Everything below is presentation of what it found.
+            VehicleStatus? status = await vehicle.QueryStatus(cancellationToken);
+            if (status == null)
             {
                 await this.ResetVehicleInfo();
                 return false;
             }
 
-            await this.Voltage.SetAsync(String.Empty);
-            Response<string> voltageResponse = await vehicle.QueryVoltage();
-            if (voltageResponse.Status == ResponseStatus.Success)
+            if (status.PcmState == VehicleStatus.State.Recovery)
             {
-                await this.Voltage.SetAsync(voltageResponse.Value ?? String.Empty);
+                logger.AddUserMessage("PCM/ECM recovery mode detected!");
+                await this.OperatingSystemId.SetAsync(_recoveryString);
+                return true;
             }
-            else
+
+            if (status.PcmState == VehicleStatus.State.Kernel)
             {
-                await this.ResetVehicleInfo();
-                return false;
+                logger.AddUserMessage($"Detected kernel version: {Vehicle.FormatKernelVersion(status.KernelVersion)}");
+                await this.OperatingSystemId.SetAsync(_kernelString);
+                return true;
             }
+
+            logger.AddDebugMessage($"Detected PCM on {status.Bus}.");
+            await this.OperatingSystemId.SetAsync(status.Osid.ToString());
+            await this.Bus.SetAsync(status.Bus.ToString());
+            await this.Voltage.SetAsync(status.Voltage);
         }
         catch (Exception exception)
         {
@@ -810,6 +806,7 @@ public class ConnectionService : IConnectionService
     {
         await this.ConnectionState.SetAsync(ConnectionStates.NotConnected);
         await this.OperatingSystemId.SetAsync(String.Empty);
+        await this.Bus.SetAsync(String.Empty);
         await this.Voltage.SetAsync(String.Empty);
     }
 

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/SettingsService.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Services/SettingsService.cs
@@ -17,7 +17,7 @@ public class SettingsChangedMessage { }
 public interface ISettingsService
 {
     string GetObd2DeviceCategory();
-    string GetJ2534DeviceName();
+    J2534DeviceListing GetJ2534Device();
     string GetBluetoothDeviceName();
     SerialPortListing GetObd2SerialPortName();
     string GetObd2SerialDeviceName();
@@ -155,9 +155,14 @@ public class SettingsService : ISettingsService
         return _settingsListInterface[BluetoothDeviceNameKey] as string ?? string.Empty;
     }
 
-    public string GetJ2534DeviceName()
+    public J2534DeviceListing GetJ2534Device()
     {
-        return _settingsListInterface[J2534DeviceNameKey] as string ?? string.Empty;
+        string result = _settingsListInterface[J2534DeviceNameKey] as string ?? string.Empty;
+        return new J2534DeviceListing
+        {
+            Name = result,
+            DisplayName = result
+        };
     }
 
     public bool IsCanEnabled()

--- a/Apps/UI/WPF/PCMHammer/Helpers/MainWindowLogger.cs
+++ b/Apps/UI/WPF/PCMHammer/Helpers/MainWindowLogger.cs
@@ -57,8 +57,15 @@ namespace PCMHammer.Helpers
 
         public void StatusUpdateKbps(string Kbps)
         {
-            if (double.TryParse(Kbps.Replace(" Kb/s", "").Replace("kbps", ""), out double result))
+            // The library sends the rate as e.g. "45.23 Kbps" (capital K), or an empty string to
+            // clear it. Take the leading numeric token so the unit's text/case can't defeat the parse
+            // (the old code only stripped a lowercase "kbps", so nothing ever parsed and the rate
+            // stayed at zero, hence invisible).
+            string number = (Kbps ?? string.Empty).Trim().Split(' ')[0];
+            if (double.TryParse(number, out double result))
                 Application.Current.Dispatcher.Invoke(() => _viewModel.TransferRate = result);
+            else if (string.IsNullOrWhiteSpace(Kbps))
+                Application.Current.Dispatcher.Invoke(() => _viewModel.TransferRate = 0);
         }
 
         public void StatusUpdateReset()

--- a/Apps/UI/WPF/PCMHammer/Helpers/MainWindowLogger.cs
+++ b/Apps/UI/WPF/PCMHammer/Helpers/MainWindowLogger.cs
@@ -50,6 +50,13 @@ public class MainWindowLogger : ILogger, IDisposable
         _debugMessageQueue.Enqueue($"[{DateTime.Now:HH:mm:ss.fff}] {message}");
     }
 
+    /// <summary>
+    /// Force any queued messages into the view model now instead of waiting for the next timer tick.
+    /// Must be called on the UI thread. Used before the logs are saved on shutdown so the saved files
+    /// include the most recent lines (they are read from the view model's LogText/DebugLogText).
+    /// </summary>
+    public void Flush() => FlushQueuesToViewModel();
+
     private void FlushQueuesToViewModel()
     {
         // 1. Process User Messages
@@ -127,8 +134,15 @@ public class MainWindowLogger : ILogger, IDisposable
 
     public void StatusUpdateKbps(string Kbps)
     {
-        if (double.TryParse(Kbps.Replace(" Kb/s", "").Replace("kbps", ""), out double result))
+        // The library sends the rate as e.g. "45.23 Kbps" (capital K), or an empty string to clear it.
+        // Take the leading numeric token so the unit's text/case can't defeat the parse - a plain
+        // Replace("kbps", ...) misses the capital-K form, so nothing parses and the rate stays at zero
+        // (invisible in the status bar).
+        string number = (Kbps ?? string.Empty).Trim().Split(' ')[0];
+        if (double.TryParse(number, out double result))
             Application.Current.Dispatcher.BeginInvoke(() => _viewModel.TransferRate = result);
+        else if (string.IsNullOrWhiteSpace(Kbps))
+            Application.Current.Dispatcher.BeginInvoke(() => _viewModel.TransferRate = 0);
     }
 
     public void StatusUpdateReset()

--- a/Apps/UI/WPF/PCMHammer/Helpers/MainWindowLogger.cs
+++ b/Apps/UI/WPF/PCMHammer/Helpers/MainWindowLogger.cs
@@ -1,83 +1,165 @@
-﻿using PcmHacking;
+using PcmHacking;
 using PCMHammer.Viewmodels;
+using System.Collections.Concurrent;
+using System.Text;
 using System.Windows;
+using System.Windows.Threading;
 
-namespace PCMHammer.Helpers
+namespace PCMHammer.Helpers;
+
+public class MainWindowLogger : ILogger, IDisposable
 {
-    public class MainWindowLogger(MainWindowViewModel viewModel) : ILogger
+    private readonly MainWindowViewModel _viewModel;
+    
+    // Thread-safe queues for log messages
+    private readonly ConcurrentQueue<string> _userMessageQueue = new();
+    private readonly ConcurrentQueue<string> _debugMessageQueue = new();
+
+    // UI Batching Timer (10 FPS)
+    private readonly DispatcherTimer _flushTimer;
+    private readonly StringBuilder _userStringBuilder = new();
+    private readonly StringBuilder _debugStringBuilder = new();
+
+    private const int MaxLogLength = 500_000;
+    private bool _isDisposed;
+
+    public MainWindowLogger(MainWindowViewModel viewModel)
     {
-        private readonly MainWindowViewModel _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
 
-        // Events
-        public event Action<double, bool>? ProgressBarUpdated;
-        public event Action<string>? StatusTextUpdated;
-
-        // Append User messages directly to the UI Log Text
-        public void AddUserMessage(string message)
+        _flushTimer = new DispatcherTimer(DispatcherPriority.Background)
         {
-            string formatted = $"[{DateTime.Now:HH:mm:ss}] {message}";
+            Interval = TimeSpan.FromMilliseconds(100)
+        };
+        _flushTimer.Tick += (s, e) => FlushQueuesToViewModel();
+        _flushTimer.Start();
+    }
 
-            Application.Current.Dispatcher.Invoke(() =>
+    // Events
+    public event Action<double, bool>? ProgressBarUpdated;
+    public event Action<string>? StatusTextUpdated;
+
+    // Fast, non-blocking enqueue
+    public void AddUserMessage(string message)
+    {
+        _userMessageQueue.Enqueue($"[{DateTime.Now:HH:mm:ss}] {message}");
+    }
+
+    public void AddDebugMessage(string message)
+    {
+        _debugMessageQueue.Enqueue($"[{DateTime.Now:HH:mm:ss.fff}] {message}");
+    }
+
+    private void FlushQueuesToViewModel()
+    {
+        // 1. Process User Messages
+        if (!_userMessageQueue.IsEmpty)
+        {
+            _userStringBuilder.Clear();
+            while (_userMessageQueue.TryDequeue(out string? msg))
             {
-                _viewModel.LogText += formatted + Environment.NewLine;
-            });
+                _userStringBuilder.AppendLine(msg);
+            }
+
+            string current = _viewModel.LogText ?? string.Empty;
+            string updated = current + _userStringBuilder.ToString();
+            
+            _viewModel.LogText = TrimToCleanLineBoundary(updated);
         }
 
-        // Append Debug messages
-        public void AddDebugMessage(string message)
+        // 2. Process Debug Messages
+        if (!_debugMessageQueue.IsEmpty)
         {
-            string formatted = $"[{DateTime.Now:HH:mm:ss.fff}] {message}";
-
-            Application.Current.Dispatcher.Invoke(() =>
+            _debugStringBuilder.Clear();
+            while (_debugMessageQueue.TryDequeue(out string? msg))
             {
-                _viewModel.DebugLogText += formatted + Environment.NewLine;
-            });
+                _debugStringBuilder.AppendLine(msg);
+            }
+
+            string current = _viewModel.DebugLogText ?? string.Empty;
+            string updated = current + _debugStringBuilder.ToString();
+
+            _viewModel.DebugLogText = TrimToCleanLineBoundary(updated);
         }
+    }
 
-        // Keep the Status indicators seamlessly in sync!
-        public void StatusUpdateActivity(string activity)
+    // Truncates log length safely at a clean newline boundary rather than mid-string
+    private static string TrimToCleanLineBoundary(string text)
+    {
+        if (text.Length <= MaxLogLength)
+            return text;
+
+        int cutIndex = text.Length - (MaxLogLength / 2);
+        int nextNewLine = text.IndexOf('\n', cutIndex);
+
+        return nextNewLine != -1 && nextNewLine < text.Length - 1
+            ? text.Substring(nextNewLine + 1)
+            : text.Substring(cutIndex);
+    }
+
+    // Status Updates: Safely Dispatch to UI Thread
+    public void StatusUpdateActivity(string activity)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() => _viewModel.StatusText = activity);
+    }
+
+    public void StatusUpdateTimeRemaining(string remaining)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() => _viewModel.TimeRemaining = remaining);
+    }
+
+    // Fixed: Marshal event invocations to the UI thread to prevent cross-thread UI exceptions
+    public void StatusUpdatePercentDone(string percent)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() => StatusTextUpdated?.Invoke(percent));
+    }
+
+    public void StatusUpdateProgressBar(double percent, bool visible)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() => ProgressBarUpdated?.Invoke(percent, visible));
+    }
+
+    public void StatusUpdateRetryCount(string retries)
+    {
+        if (int.TryParse(retries, out int result))
+            Application.Current.Dispatcher.BeginInvoke(() => _viewModel.RetryCount = result);
+    }
+
+    public void StatusUpdateKbps(string Kbps)
+    {
+        if (double.TryParse(Kbps.Replace(" Kb/s", "").Replace("kbps", ""), out double result))
+            Application.Current.Dispatcher.BeginInvoke(() => _viewModel.TransferRate = result);
+    }
+
+    public void StatusUpdateReset()
+    {
+        // Use synchronous Invoke here so reset state is guaranteed immediately for caller
+        Application.Current.Dispatcher.Invoke(() =>
         {
-            Application.Current.Dispatcher.Invoke(() => _viewModel.StatusText = activity);
+            _viewModel.StatusText = "Ready";
+            _viewModel.ProgressPercent = 0;
+            _viewModel.RetryCount = 0;
+            _viewModel.TransferRate = 0;
+            _viewModel.TimeRemaining = string.Empty;
+        });
+    }
+
+    // Fixed: Dispose now executes a final synchronous flush on the UI thread to prevent data loss on shutdown
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+
+        _flushTimer.Stop();
+
+        // Perform final flush on Dispatcher to catch remaining messages
+        if (Application.Current != null && Application.Current.Dispatcher != null)
+        {
+            Application.Current.Dispatcher.Invoke(FlushQueuesToViewModel);
         }
-
-        public void StatusUpdateTimeRemaining(string remaining)
+        else
         {
-            Application.Current.Dispatcher.Invoke(() => _viewModel.TimeRemaining = remaining);
-        }
-
-        public void StatusUpdatePercentDone(string percent) => StatusTextUpdated?.Invoke(percent);
-
-        public void StatusUpdateProgressBar(double percent, bool visible) => ProgressBarUpdated?.Invoke(percent, visible);
-
-        public void StatusUpdateRetryCount(string retries)
-        {
-            if (int.TryParse(retries, out int result))
-                Application.Current.Dispatcher.Invoke(() => _viewModel.RetryCount = result);
-        }
-
-        public void StatusUpdateKbps(string Kbps)
-        {
-            // The library sends the rate as e.g. "45.23 Kbps" (capital K), or an empty string to
-            // clear it. Take the leading numeric token so the unit's text/case can't defeat the parse
-            // (the old code only stripped a lowercase "kbps", so nothing ever parsed and the rate
-            // stayed at zero, hence invisible).
-            string number = (Kbps ?? string.Empty).Trim().Split(' ')[0];
-            if (double.TryParse(number, out double result))
-                Application.Current.Dispatcher.Invoke(() => _viewModel.TransferRate = result);
-            else if (string.IsNullOrWhiteSpace(Kbps))
-                Application.Current.Dispatcher.Invoke(() => _viewModel.TransferRate = 0);
-        }
-
-        public void StatusUpdateReset()
-        {
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                _viewModel.StatusText = "Ready";
-                _viewModel.ProgressPercent = 0;
-                _viewModel.RetryCount = 0;
-                _viewModel.TransferRate = 0;
-                _viewModel.TimeRemaining = string.Empty;
-            });
+            FlushQueuesToViewModel();
         }
     }
 }

--- a/Apps/UI/WPF/PCMHammer/PCMHammer.csproj
+++ b/Apps/UI/WPF/PCMHammer/PCMHammer.csproj
@@ -3,13 +3,34 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <!-- Run 32-bit so the process can load 32-bit J2534 driver DLLs (a 64-bit process cannot).
+         Most J2534 drivers ship 32-bit only; the WinForms app runs 32-bit for the same reason. -->
+    <PlatformTarget>x86</PlatformTarget>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>0411_256px.ico</ApplicationIcon>
 	<LangVersion>14.0</LangVersion>
+    <!-- Untagged dev builds report 0.0.0.0 so AppInfo shows the build date instead of a version;
+         the release pipeline stamps a real version. Matches the WinForms/CLI convention. -->
+    <Version>0.0.0.0</Version>
+    <FileVersion>0.0.0.0</FileVersion>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </PropertyGroup>
+
+  <Target Name="Date" BeforeTargets="CoreCompile">
+    <!-- Writes Generated.BuildTime (the compile timestamp) so the About/log lines can show a
+         "Build: <date time>" for untagged builds. BuildTicks can be passed in (/p:BuildTicks=...)
+         so every assembly in one build shares the same timestamp; defaults to UtcNow otherwise. -->
+    <PropertyGroup>
+      <BuildTicks Condition="'$(BuildTicks)' == ''">$([System.DateTime]::UtcNow.Ticks)</BuildTicks>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(IntermediateOutputPath)generated.cs" Lines="static partial class Generated { public static long BuildTime = $(BuildTicks)%3B }" Overwrite="true" />
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)generated.cs" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <Content Include="0411_256px.ico" />

--- a/Apps/UI/WPF/PCMHammer/Properties/Settings.Designer.cs
+++ b/Apps/UI/WPF/PCMHammer/Properties/Settings.Designer.cs
@@ -37,7 +37,7 @@ namespace PCMHammer.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool RetainDeviceConfigurationOnExit {
             get {
                 return ((bool)(this["RetainDeviceConfigurationOnExit"]));

--- a/Apps/UI/WPF/PCMHammer/Properties/Settings.settings
+++ b/Apps/UI/WPF/PCMHammer/Properties/Settings.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="RetainDeviceConfigurationOnExit" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="SavedSerialPort" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
@@ -21,13 +21,13 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="SavedDevice4xCommunicationEnabled" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="UseLogSaveAsDialog" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="SaveResultsLogOnExit" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="SaveDebugLogOnExit" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/Apps/UI/WPF/PCMHammer/Services/FileDialogService.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/FileDialogService.cs
@@ -45,6 +45,60 @@ namespace PCMHammer.Services
             return saveFileDialog.ShowDialog() == true ? saveFileDialog.FileName : null;
         }
 
+        public string? OpenPackageFileDialog()
+        {
+            OpenFileDialog openFileDialog = new()
+            {
+                Title = "Load PCM File",
+                Filter = "PcmHammer files (*.phz;*.bin)|*.phz;*.bin|PcmHammer package (*.phz)|*.phz|Binary Files (*.bin)|*.bin|All Files (*.*)|*.*",
+                DefaultExt = ".phz"
+            };
+
+            if (!string.IsNullOrWhiteSpace(Properties.Settings.Default.BinDirectory))
+                openFileDialog.InitialDirectory = Properties.Settings.Default.BinDirectory;
+
+            return openFileDialog.ShowDialog() == true ? openFileDialog.FileName : null;
+        }
+
+        public string? SavePackageFileDialog(bool complete, string suggestedName)
+        {
+            // A complete package can be saved as a self-contained .phz (default) or a raw master .bin; an
+            // incomplete document (e.g. a master-only bin for a slave-bearing PCM) offers only .bin so an
+            // invalid package can never be produced.
+            SaveFileDialog saveFileDialog = new()
+            {
+                Title = "Save PCM File",
+                Filter = complete
+                    ? "PcmHammer package (*.phz)|*.phz|Binary Files (*.bin)|*.bin"
+                    : "Binary Files (*.bin)|*.bin",
+                DefaultExt = complete ? ".phz" : ".bin",
+                FileName = string.IsNullOrWhiteSpace(suggestedName) ? "PCM_Read" : suggestedName,
+                OverwritePrompt = true
+            };
+
+            if (!string.IsNullOrWhiteSpace(Properties.Settings.Default.BinDirectory))
+                saveFileDialog.InitialDirectory = Properties.Settings.Default.BinDirectory;
+
+            return saveFileDialog.ShowDialog() == true ? saveFileDialog.FileName : null;
+        }
+
+        public string? ExportBinBaseDialog(string suggestedName)
+        {
+            SaveFileDialog saveFileDialog = new()
+            {
+                Title = "Export Bin",
+                Filter = "Binary Files (*.bin)|*.bin",
+                DefaultExt = ".bin",
+                FileName = string.IsNullOrWhiteSpace(suggestedName) ? "export" : suggestedName,
+                OverwritePrompt = false
+            };
+
+            if (!string.IsNullOrWhiteSpace(Properties.Settings.Default.BinDirectory))
+                saveFileDialog.InitialDirectory = Properties.Settings.Default.BinDirectory;
+
+            return saveFileDialog.ShowDialog() == true ? saveFileDialog.FileName : null;
+        }
+
         public string GetLogSavePath(string defaultFileName)
         {
             // Interactive Dialog Prompt Branch

--- a/Apps/UI/WPF/PCMHammer/Services/FileDialogService.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/FileDialogService.cs
@@ -49,8 +49,8 @@ namespace PCMHammer.Services
         {
             OpenFileDialog openFileDialog = new()
             {
-                Title = "Load PCM File",
-                Filter = "PcmHammer files (*.phz;*.bin)|*.phz;*.bin|PcmHammer package (*.phz)|*.phz|Binary Files (*.bin)|*.bin|All Files (*.*)|*.*",
+                Title = "Load PCMHammer File",
+                Filter = "PcmHammer files (*.phz;*.bin)|*.phz;*.bin|PcmHammer (*.phz)|*.phz|Binary Files (*.bin)|*.bin|All Files (*.*)|*.*",
                 DefaultExt = ".phz"
             };
 
@@ -67,9 +67,9 @@ namespace PCMHammer.Services
             // invalid package can never be produced.
             SaveFileDialog saveFileDialog = new()
             {
-                Title = "Save PCM File",
+                Title = "Save PCMHamer File",
                 Filter = complete
-                    ? "PcmHammer package (*.phz)|*.phz|Binary Files (*.bin)|*.bin"
+                    ? "PcmHammer (*.phz)|*.phz|Binary Files (*.bin)|*.bin"
                     : "Binary Files (*.bin)|*.bin",
                 DefaultExt = complete ? ".phz" : ".bin",
                 FileName = string.IsNullOrWhiteSpace(suggestedName) ? "PCM_Read" : suggestedName,

--- a/Apps/UI/WPF/PCMHammer/Services/IFileDialogService.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/IFileDialogService.cs
@@ -22,6 +22,30 @@
         string? SaveBinFileDialog();
 
         /// <summary>
+        /// Prompts the user to open a PcmHammer document (a .phz package or a raw .bin) to load into the
+        /// working document.
+        /// </summary>
+        /// <returns>The full path to the file, or null if canceled.</returns>
+        string? OpenPackageFileDialog();
+
+        /// <summary>
+        /// Prompts for a save destination for the working document. A complete package may be saved as
+        /// .phz (default) or .bin; an incomplete one may only be saved as .bin.
+        /// </summary>
+        /// <param name="complete">Whether the document is a complete package (offers .phz).</param>
+        /// <param name="suggestedName">A default file name (without extension) to pre-fill.</param>
+        /// <returns>The chosen path, or null if canceled.</returns>
+        string? SavePackageFileDialog(bool complete, string suggestedName);
+
+        /// <summary>
+        /// Prompts for the base path used when exporting one or more images as raw .bin files. The caller
+        /// derives per-image file names from this base.
+        /// </summary>
+        /// <param name="suggestedName">A default base file name (without extension) to pre-fill.</param>
+        /// <returns>The chosen base path, or null if canceled.</returns>
+        string? ExportBinBaseDialog(string suggestedName);
+
+        /// <summary>
         /// Handles customizable log saving locations
         /// </summary>
         /// <param name="defaultFileName">The default file name to use if the user does not specify one.</param>

--- a/Apps/UI/WPF/PCMHammer/Services/PCMReader.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/PCMReader.cs
@@ -4,26 +4,81 @@ namespace PCMHammer.Services
 {
     public class PcmReader(Vehicle vehicle, ILogger logger)
     {
-        public Task Alert(string title, string message)
+        // Parameter order is (message, title), matching the library's promptForYesNo/alert delegates
+        // and the WinForms implementation.
+        public Task Alert(string message, string title)
         {
             logger.AddUserMessage($"ALERT [{title}]: {message}");
             return Task.CompletedTask;
         }
 
-        public static async Task<bool> PromptForYesNo(string title, string message)
+        public static Task<bool> PromptForYesNo(string message, string title) => ShowYesNo(message, title);
+
+        /// <summary>
+        /// Show a Yes/No dialog and return the answer as a COMPLETED task. This must run synchronously:
+        /// the library calls it fire-and-forget through its UI-thread marshaller, and an async gap (as an
+        /// awaited Dispatcher.InvokeAsync introduces) would let the caller read the default before the
+        /// user answers - which showed up as every warning being treated as "No" / abort.
+        /// </summary>
+        internal static Task<bool> ShowYesNo(string message, string title)
         {
-            bool userResult = false;
-            await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                var result = System.Windows.MessageBox.Show(message, title, System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Question);
-                userResult = (result == System.Windows.MessageBoxResult.Yes);
-            });
-            return userResult;
+            var dispatcher = System.Windows.Application.Current.Dispatcher;
+            bool Ask() => System.Windows.MessageBox.Show(
+                message, title, System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Question)
+                == System.Windows.MessageBoxResult.Yes;
+
+            bool result = dispatcher.CheckAccess() ? Ask() : dispatcher.Invoke(Ask);
+            return Task.FromResult(result);
         }
 
         // These fallbacks map to ReadManager expectations if it encounters complex/deep OS query scenarios
         private Task<string> DummyPromptForFile() => Task.FromResult(string.Empty);
         private Task<PcmType> DummyPromptForOsId() => Task.FromResult(PcmType.Undefined);
+
+        /// <summary>
+        /// Read the PCM into an in-memory working document (a <see cref="PcmPackage"/>), the way the
+        /// WinForms app does: the read produces a package the UI holds and can then save or flash, with
+        /// no intermediate file on disk. Returns null if nothing was read.
+        /// </summary>
+        public async Task<PcmPackage?> ReadToPackageAsync(
+            bool useAutoPcmType = true,
+            PcmType selectedPcmType = PcmType.Undefined,
+            CancellationToken cancellationToken = default)
+        {
+            using (new AwayMode())
+            {
+                try
+                {
+                    if (vehicle == null)
+                    {
+                        logger.AddUserMessage("Error: No vehicle interface connected.");
+                        return null;
+                    }
+
+                    PcmType forcedPcmType = useAutoPcmType ? PcmType.Undefined : selectedPcmType;
+
+                    ReadManager reader = new(
+                        logger,
+                        vehicle,
+                        (action) => {
+                            System.Windows.Application.Current.Dispatcher.Invoke(action);
+                            return Task.CompletedTask;
+                        },
+                        DummyPromptForFile!,
+                        DummyPromptForOsId!,
+                        Alert,
+                        PromptForYesNo,
+                        cancellationToken);
+
+                    return await reader.ReadToPackage(forcedPcmType);
+                }
+                catch (Exception exception)
+                {
+                    logger.AddUserMessage($"Read failed: {exception.Message}");
+                    return null;
+                }
+            }
+        }
 
         public async Task<bool> ReadPcmAsync(
             string path,

--- a/Apps/UI/WPF/PCMHammer/Services/PcmFlasher.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/PcmFlasher.cs
@@ -8,21 +8,66 @@ namespace PCMHammer.Services
         // Track the current operations state locally
         private WriteType _currentWriteType = WriteType.None;
 
-        public Task Alert(string title, string message)
+        // Parameter order is (message, title), matching the library's promptForYesNo/alert delegates
+        // and the WinForms implementation.
+        public Task Alert(string message, string title)
         {
             logger.AddUserMessage($"ALERT [{title}]: {message}");
             return Task.CompletedTask;
         }
 
-        public async Task<bool> PromptForYesNo(string title, string message)
+        // Delegates to the shared, synchronous implementation. It must complete synchronously because the
+        // library calls it fire-and-forget through its UI-thread marshaller; an awaited async gap would
+        // let the caller read the default before the user answers (every warning read as "No" / abort).
+        public Task<bool> PromptForYesNo(string message, string title) => PcmReader.ShowYesNo(message, title);
+
+        /// <summary>
+        /// Flash the in-memory working document (a <see cref="PcmPackage"/>) instead of a file on disk.
+        /// The bytes come from the loaded package; this is the WinForms "write the loaded file" path,
+        /// used by Write / Test Write / Verify once a document is loaded or freshly read.
+        /// </summary>
+        public async Task<bool> WritePackageAsync(
+            WriteType writeType,
+            PcmPackage package,
+            bool useAutoPcmType = true,
+            PcmType selectedPcmType = PcmType.Undefined,
+            CancellationToken cancellationToken = default,
+            bool suppressOSIDWarning = false)
         {
-            bool userResult = false;
-            await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+            using (new AwayMode())
             {
-                var result = System.Windows.MessageBox.Show(message, title, System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Question);
-                userResult = (result == System.Windows.MessageBoxResult.Yes);
-            });
-            return userResult;
+                try
+                {
+                    _currentWriteType = writeType;
+
+                    if (vehicle == null)
+                    {
+                        logger.AddUserMessage("Error: No vehicle interface connected.");
+                        return false;
+                    }
+
+                    PcmType forcedPcmType = useAutoPcmType ? PcmType.Undefined : selectedPcmType;
+
+                    WriteManager writer = new(
+                        logger,
+                        vehicle,
+                        writeType,
+                        Alert,
+                        PromptForYesNo,
+                        cancellationToken);
+
+                    return await writer.Write(package, forcedPcmType, suppressOSIDWarning);
+                }
+                catch (IOException exception)
+                {
+                    logger.AddUserMessage(exception.ToString());
+                    return false;
+                }
+                finally
+                {
+                    _currentWriteType = WriteType.None;
+                }
+            }
         }
 
         public async Task<bool> WritePcmAsync(

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/DevicePickerViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/DevicePickerViewModel.cs
@@ -503,22 +503,32 @@ namespace PCMHammer.Viewmodels
             string target;
             string onPort = string.Empty;
 
-            if (SerialPort == null) return;
-
-            var match = SerialPortRegex().Match(SerialPort!.PortName!);
-            if (match.Success && SerialPort.PortName!.Length > 4)
+            if (DeviceCategory == DeviceConfiguration.Constants.DeviceCategorySerial)
             {
-                string cleanedName = match.Groups[0].Value;
-                SerialPort = SerialPorts.FirstOrDefault(p => p.PortName == cleanedName);
-            }
+                // Only the serial path needs a port; a J2534 selection has none.
+                if (SerialPort == null)
+                {
+                    StatusText = "Choose a serial port first.";
+                    if (ShowInfoAlertAsync != null)
+                    {
+                        await ShowInfoAlertAsync("Choose a serial port first.", "Test Device");
+                    }
+                    return;
+                }
 
-            if (IsSerialDeviceSelected)
-            {
+                // A pasted or expanded name (e.g. "COM5 (USB Serial)") is reduced to "COM5".
+                var match = SerialPortRegex().Match(SerialPort!.PortName!);
+                if (match.Success && SerialPort.PortName!.Length > 4)
+                {
+                    string cleanedName = match.Groups[0].Value;
+                    SerialPort = SerialPorts.FirstOrDefault(p => p.PortName == cleanedName);
+                }
+
                 device = DeviceFactory.CreateSerialDevice(SerialPort!.PortName!, SerialPortDeviceType, logger);
                 onPort = " on " + (SerialPort!.PortName! ?? "(no port)");
                 target = (SerialPortDeviceType ?? "serial device") + onPort;
             }
-            else if (IsJ2534DeviceSelected)
+            else if (DeviceCategory == DeviceConfiguration.Constants.DeviceCategoryJ2534)
             {
                 device = DeviceFactory.CreateJ2534Device(J2534DeviceType, logger);
                 target = J2534DeviceType ?? "J2534 device";

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
@@ -1,0 +1,405 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PcmHacking;
+using PCMHammer.Views.DialogBoxes;
+using System.IO;
+using System.Linq;
+using System.Windows;
+
+namespace PCMHammer.Viewmodels
+{
+    /// <summary>
+    /// The "loaded file" document model, mirroring the WinForms app: the app holds one working document
+    /// (a <see cref="PcmPackage"/>) in memory. A Read produces it, Load File opens a .phz or .bin into it,
+    /// and Write / Test Write / Verify / Export all act on it - no file is picked at operation time. Save
+    /// writes it back out (as .phz when complete, otherwise .bin).
+    /// </summary>
+    public partial class MainWindowViewModel
+    {
+        #region Document state
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(HasDocument))]
+        [NotifyPropertyChangedFor(nameof(CanWriteDocument))]
+        [NotifyPropertyChangedFor(nameof(CanUseDocument))]
+        [NotifyPropertyChangedFor(nameof(LoadedFileText))]
+        [NotifyPropertyChangedFor(nameof(WindowTitle))]
+        public partial PcmPackage? LoadedPackage { get; set; }
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(LoadedFileText))]
+        [NotifyPropertyChangedFor(nameof(WindowTitle))]
+        public partial string? LoadedPackagePath { get; set; }
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(LoadedFileText))]
+        [NotifyPropertyChangedFor(nameof(WindowTitle))]
+        public partial bool DocumentDirty { get; set; }
+
+        /// <summary>True when a working document is loaded.</summary>
+        public bool HasDocument => LoadedPackage is not null;
+
+        /// <summary>
+        /// True when the loaded document may be flashed/verified: a document is loaded, a device is
+        /// connected, and nothing is running. Write / Test Write / Verify bind to this.
+        /// </summary>
+        public bool CanWriteDocument => HasDocument && CanStartOperation;
+
+        /// <summary>
+        /// True when a document operation that needs no device (Save, Export, Import) is allowed: a
+        /// document is loaded and nothing is running.
+        /// </summary>
+        public bool CanUseDocument => HasDocument && !IsOperationRunning;
+
+        /// <summary>True when the (hidden by default) Import Bin feature is enabled.</summary>
+        public bool IsModuleImportAllowed => RuntimeSettings.AllowModuleImport;
+
+        /// <summary>The window title, showing the loaded file and a "*" when it has unsaved changes.</summary>
+        public string WindowTitle =>
+            HasDocument ? "PCM Hammer - " + DocumentDisplayName() + (DocumentDirty ? " *" : string.Empty) : "PCM Hammer";
+
+        /// <summary>The two-line "loaded file" panel text: the file name (with dirty mark) and a summary.</summary>
+        public string LoadedFileText =>
+            LoadedPackage == null
+                ? "No file loaded"
+                : DocumentDisplayName() + (DocumentDirty ? " *" : string.Empty) + Environment.NewLine + DescribeDocument(LoadedPackage);
+
+        #endregion
+
+        #region Document commands
+
+        [RelayCommand]
+        public void LoadFile()
+        {
+            if (IsOperationRunning)
+            {
+                return;
+            }
+
+            if (!ConfirmDiscardIfDirty())
+            {
+                return;
+            }
+
+            string? path = _fileDialogService.OpenPackageFileDialog();
+            if (path == null)
+            {
+                return;
+            }
+
+            try
+            {
+                PcmPackage package = PackageStore.Load(path);
+
+                // A raw .bin has no recorded type/OSID; identify its main image now, and reject anything
+                // that isn't a recognized master (e.g. a lone slave module bin, which is not usable alone).
+                if (!IdentifyLoadedMain(package))
+                {
+                    return;
+                }
+
+                SetLoadedPackage(package, path, dirty: false);
+                _logger.AddUserMessage("Loaded " + path);
+                _logger.AddUserMessage("  " + DescribeDocument(package));
+                WarnIfIncomplete(package);
+                StatusText = "File loaded.";
+            }
+            catch (PackageException exception)
+            {
+                _logger.AddUserMessage("Unable to load file: " + exception.Message);
+                MessageBox.Show(exception.Message, "Could not load file", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        public void SaveFile() => SaveDocument(forcePrompt: true);
+
+        [RelayCommand]
+        public void SaveFileAs() => SaveDocument(forcePrompt: true);
+
+        [RelayCommand]
+        public void ImportModule()
+        {
+            if (IsOperationRunning || LoadedPackage == null || !RuntimeSettings.AllowModuleImport)
+            {
+                return;
+            }
+
+            ModuleImportDialog dialog = new(LoadedPackage, _logger) { Owner = _parentWindow };
+            dialog.ShowDialog();
+            if (dialog.Changed)
+            {
+                MarkDocumentDirty();
+            }
+        }
+
+        [RelayCommand]
+        public void ExportBin()
+        {
+            if (IsOperationRunning || LoadedPackage == null)
+            {
+                return;
+            }
+
+            ExportBinDialogBox dialog = new(LoadedPackage) { Owner = _parentWindow };
+            if (!dialog.HasExportableImages)
+            {
+                MessageBox.Show("This file has no image data to export.", "Export Bin", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            if (dialog.ShowDialog() != true || dialog.SelectedImages.Count == 0)
+            {
+                return;
+            }
+
+            string? basePath = _fileDialogService.ExportBinBaseDialog(DocumentDisplayName());
+            if (basePath == null)
+            {
+                return;
+            }
+
+            string dir = Path.GetDirectoryName(basePath) ?? string.Empty;
+            string baseName = Path.GetFileNameWithoutExtension(basePath);
+
+            foreach (ExportBinSelection item in dialog.SelectedImages)
+            {
+                string pcmType = item.Controller.ModuleType ?? item.Controller.Type ?? "PCM";
+                string target = item.Image.Target ?? "image";
+                string fileName = string.Format("{0}_{1}_{2}.bin", baseName, pcmType, target);
+                string full = Path.Combine(dir, fileName);
+
+                // Embedded images carry their own bytes; a reference (e.g. an E38 slave) is copied out of
+                // the local slave library.
+                byte[]? bytes = item.Image.Data ?? SlaveLibrary.Resolve(item.Image.FileName);
+                if (bytes == null)
+                {
+                    _logger.AddUserMessage(string.Format(
+                        "Skipped {0}: \"{1}\" is not in the local library.", target, item.Image.FileName));
+                    continue;
+                }
+
+                try
+                {
+                    File.WriteAllBytes(full, bytes);
+                    _logger.AddUserMessage("Exported " + full);
+                }
+                catch (Exception exception)
+                {
+                    _logger.AddUserMessage("Failed to export " + fileName + ": " + exception.Message);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Document helpers
+
+        /// <summary>
+        /// Called when the window is closing: if the working document has unsaved changes, offer to save,
+        /// discard, or cancel. Returns false only when the user cancels (the close should be aborted).
+        /// </summary>
+        public bool ConfirmDiscardOnExit() => ConfirmDiscardIfDirty();
+
+        /// <summary>Set (or clear) the working document and refresh the title and the file panel.</summary>
+        private void SetLoadedPackage(PcmPackage? package, string? path, bool dirty)
+        {
+            LoadedPackage = package;
+            LoadedPackagePath = path;
+            DocumentDirty = package != null && dirty;
+        }
+
+        /// <summary>Mark the working document changed (e.g. after Import) and refresh the display.</summary>
+        private void MarkDocumentDirty()
+        {
+            if (LoadedPackage == null)
+            {
+                return;
+            }
+
+            DocumentDirty = true;
+        }
+
+        /// <summary>
+        /// If the working document has unsaved changes, ask whether to save, discard, or cancel. Returns
+        /// false only when the user cancels (the caller should abort whatever would discard the document).
+        /// </summary>
+        private bool ConfirmDiscardIfDirty()
+        {
+            if (LoadedPackage == null || !DocumentDirty)
+            {
+                return true;
+            }
+
+            MessageBoxResult choice = MessageBox.Show(
+                "The loaded file has unsaved changes. Save them first?",
+                "Unsaved changes",
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Warning);
+
+            return choice switch
+            {
+                MessageBoxResult.Yes => SaveDocument(forcePrompt: false),
+                MessageBoxResult.No => true,
+                _ => false,
+            };
+        }
+
+        /// <summary>After a read, offer to save the fresh document immediately.</summary>
+        private void PromptSaveAfterRead()
+        {
+            MessageBoxResult choice = MessageBox.Show(
+                "Read complete. Save it to a file now?",
+                "Save", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (choice == MessageBoxResult.Yes)
+            {
+                SaveDocument(forcePrompt: true);
+            }
+        }
+
+        /// <summary>
+        /// Save the working document. A complete package may be written as .phz or .bin; an incomplete one
+        /// may only be saved as .bin - the .phz option is refused so we never write a package with missing
+        /// modules. Returns true on a successful save.
+        /// </summary>
+        private bool SaveDocument(bool forcePrompt)
+        {
+            if (LoadedPackage == null)
+            {
+                return false;
+            }
+
+            bool complete = PackageCompleteness.IsComplete(LoadedPackage, out string reason);
+            string? path = forcePrompt ? null : LoadedPackagePath;
+
+            // A remembered path is only reusable if it still satisfies the completeness rule for its type.
+            if (path != null && !complete && path.EndsWith(".phz", StringComparison.OrdinalIgnoreCase))
+            {
+                path = null;
+            }
+
+            if (path == null)
+            {
+                path = _fileDialogService.SavePackageFileDialog(complete, DocumentDisplayName());
+                if (path == null)
+                {
+                    return false;
+                }
+            }
+
+            if (!complete && path.EndsWith(".phz", StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBox.Show(
+                    "This file cannot be saved as a package (.phz): " + reason + Environment.NewLine +
+                    "Save it as a .bin instead.",
+                    "Incomplete package", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return false;
+            }
+
+            try
+            {
+                PackageStore.Save(path, LoadedPackage);
+                LoadedPackagePath = path;
+                DocumentDirty = false;
+                _logger.AddUserMessage("Saved " + path);
+                StatusText = "File saved.";
+                return true;
+            }
+            catch (Exception exception) when (exception is IOException || exception is PackageException)
+            {
+                _logger.AddUserMessage("Unable to save file: " + exception.Message);
+                MessageBox.Show(exception.Message, "Could not save file", MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Identify the main image of a just-loaded package. A .phz already carries its module type and
+        /// OSID, so only a raw .bin is identified here: if it is not a recognized main image, the load is
+        /// rejected. On success the detected type and OSID are filled in. Returns false when rejected.
+        /// </summary>
+        private bool IdentifyLoadedMain(PcmPackage package)
+        {
+            foreach (PackageController controller in package.Controllers)
+            {
+                PackageImage? main = controller.Image("main");
+                if (main?.Data == null)
+                {
+                    continue;
+                }
+
+                // Already identified (a .phz records both); trust it and skip re-identification.
+                if (!string.IsNullOrEmpty(controller.ModuleType) && main.Osid != null)
+                {
+                    continue;
+                }
+
+                FileValidator validator = new(main.Data, _logger);
+                PcmType type = validator.GetFileType();
+                if (type == PcmType.Undefined)
+                {
+                    string message =
+                        "This file is not a recognized PCM image, so it cannot be loaded on its own." + Environment.NewLine +
+                        "A slave module can only be brought in with File -> Import Bin, into a package read from a PCM.";
+                    _logger.AddUserMessage(message);
+                    MessageBox.Show(message, "Unrecognized file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(controller.ModuleType))
+                {
+                    controller.ModuleType = type.ToString();
+                }
+
+                if (main.Osid == null)
+                {
+                    uint osid = validator.GetOsidFromImage();
+                    if (osid != 0)
+                    {
+                        main.Osid = osid;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// After loading, note when the document is a master image for a platform that has a slave but no
+        /// slave data (e.g. a downloaded E38 .bin): it can be flashed master-only, but it isn't a complete
+        /// package and can only be saved as a .bin.
+        /// </summary>
+        private void WarnIfIncomplete(PcmPackage package)
+        {
+            if (!PackageCompleteness.IsComplete(package, out string reason))
+            {
+                _logger.AddUserMessage("Note: " + reason + " It can be flashed as a master-only image and saved as a .bin.");
+            }
+        }
+
+        /// <summary>The display file name for the working document (falls back to an unsaved-read label).</summary>
+        private string DocumentDisplayName() =>
+            LoadedPackagePath != null ? Path.GetFileName(LoadedPackagePath) : "Untitled (unsaved read)";
+
+        /// <summary>One-line summary of a package: module type, OSID, and whether it carries the slave.</summary>
+        private static string DescribeDocument(PcmPackage package)
+        {
+            PackageController? controller = package.Controllers.FirstOrDefault();
+            if (controller == null)
+            {
+                return "empty";
+            }
+
+            string module = controller.ModuleType ?? controller.Type ?? "PCM";
+            PackageImage? main = controller.Image("main");
+            string osid = main?.Osid != null ? ", OSID " + main.Osid : string.Empty;
+            bool hasSlave = controller.Images.Any(
+                i => i.Target != null && i.Target.StartsWith("slave", StringComparison.OrdinalIgnoreCase));
+            bool complete = PackageCompleteness.IsComplete(package, out _);
+            string shape = hasSlave ? "master+slave" : (complete ? "master" : "master only");
+            return module + osid + ", " + shape;
+        }
+
+        #endregion
+    }
+}

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
@@ -68,7 +68,7 @@ namespace PCMHammer.Viewmodels
 
         #region Document commands
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(IsDeviceControlEnabled))]
         public void LoadFile()
         {
             if (IsOperationRunning)
@@ -111,13 +111,13 @@ namespace PCMHammer.Viewmodels
             }
         }
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanUseDocument))]
         public void SaveFile() => SaveDocument(forcePrompt: true);
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanUseDocument))]
         public void SaveFileAs() => SaveDocument(forcePrompt: true);
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanUseDocument))]
         public void ImportModule()
         {
             if (IsOperationRunning || LoadedPackage == null || !RuntimeSettings.AllowModuleImport)
@@ -133,7 +133,7 @@ namespace PCMHammer.Viewmodels
             }
         }
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanUseDocument))]
         public void ExportBin()
         {
             if (IsOperationRunning || LoadedPackage == null)

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
@@ -377,6 +377,10 @@ namespace PCMHammer.Viewmodels
 
         public async Task HandleApplicationShutdownAsync()
         {
+            // The logger batches messages and flushes them on a timer; flush now (we are on the UI
+            // thread) so the logs we save below include every message up to this point.
+            _logger.Flush();
+
             var tasks = new List<Task>();
 
             if (Properties.Settings.Default.SaveResultsLogOnExit && SaveResultsLogCommand.CanExecute(null))
@@ -413,6 +417,10 @@ namespace PCMHammer.Viewmodels
             {
                 _logger.AddDebugMessage("Device cleanup on shutdown failed: " + exception.Message);
             }
+
+            // Stop the logger's flush timer and do its final flush (the logger implements IDisposable
+            // for exactly this). Last so any messages from the cleanup above are still captured.
+            _logger.Dispose();
         }
 
         #region Command Execution Methods

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
@@ -28,6 +28,9 @@ namespace PCMHammer.Viewmodels
         public partial PcmReader? PcmReader { get; set; }
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(CanStartOperation))]
+        [NotifyPropertyChangedFor(nameof(CanWriteDocument))]
+        [NotifyCanExecuteChangedFor(nameof(ReInitializeDeviceCommand))]
         public partial Device? SelectedDevice { get; set; }
 
         [ObservableProperty]
@@ -58,7 +61,24 @@ namespace PCMHammer.Viewmodels
         public partial Vehicle? Vehicle { get; set; }
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(CanStartOperation))]
+        [NotifyPropertyChangedFor(nameof(IsDeviceControlEnabled))]
+        [NotifyPropertyChangedFor(nameof(CanWriteDocument))]
+        [NotifyPropertyChangedFor(nameof(CanUseDocument))]
         public partial bool IsOperationRunning { get; set; }
+
+        /// <summary>
+        /// True when a new operation may be started: a device is connected and nothing is running.
+        /// The Operations buttons and the operation menu items bind their IsEnabled to this, so they
+        /// grey out for the duration of a read/write/verify instead of inviting a second command.
+        /// </summary>
+        public bool CanStartOperation => SelectedDevice is not null && !IsOperationRunning;
+
+        /// <summary>
+        /// True when device-level controls (Select / Re-Initialize, file loading) are allowed: simply
+        /// when no operation is running. These do not require a device to already be present.
+        /// </summary>
+        public bool IsDeviceControlEnabled => !IsOperationRunning;
 
         #endregion
 
@@ -178,6 +198,9 @@ namespace PCMHammer.Viewmodels
             StatusText = "Settings...";
             if (settingsWindow.ShowDialog() == true)
                 StatusText = "Ready";
+
+            // The settings dialog can toggle RuntimeSettings.AllowModuleImport; refresh the menu binding.
+            OnPropertyChanged(nameof(IsModuleImportAllowed));
         }
         #endregion
 
@@ -233,81 +256,19 @@ namespace PCMHammer.Viewmodels
                 IsOperationRunning = true;
                 await Task.Run(async () =>
                 {
-                    OSIDInfo? pcmInfo = null;
-
-                    var vinResponse = await Vehicle.QueryVin();
-                    if (vinResponse.Status != ResponseStatus.Success)
+                    // One shared flow detects the bus (VPW or CAN) and reads the identification; the
+                    // UI only logs what it returns.
+                    PcmIdentity? identity = await Vehicle.ReadIdentity(CancellationToken.None);
+                    if (identity == null)
                     {
-                        _logger.AddUserMessage($"VIN query failed: {vinResponse.Status}");
-                        await Vehicle.ExitKernel();
+                        _logger.AddUserMessage("No PCM detected.");
                         return;
                     }
-                    _logger.AddUserMessage($"VIN: {vinResponse.Value}");
 
-                    var osResponse = await Vehicle.QueryOperatingSystemId(new CancellationToken());
-                    if (osResponse.Status == ResponseStatus.Success)
+                    foreach (string line in identity.Lines)
                     {
-                        _logger.AddUserMessage($"OSID: {osResponse.Value}");
-                        pcmInfo = new OSIDInfo(osResponse.Value);
-                        _logger.AddUserMessage($"Description: {pcmInfo.Description}");
+                        _logger.AddUserMessage(line);
                     }
-                    else
-                        _logger.AddUserMessage($"OS ID query failed: {osResponse.Status}");
-
-                    // Disable Calibration ID lookup for those that do not provide it
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.BlackBox)
-                    {
-                        var calResponse = await Vehicle.QueryCalibrationId();
-                        if (calResponse.Status == ResponseStatus.Success)
-                            _logger.AddUserMessage($"Calibration ID: {calResponse.Value}");
-                        else
-                            _logger.AddUserMessage($"Calibration ID query failed: {calResponse.Status}");
-                    }
-
-                    // Disable HardwareID lookup for the P05, P10, P12 and E54.
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.P05 &&
-                        pcmInfo.HardwareType != PcmType.P05b && pcmInfo.HardwareType != PcmType.P10 &&
-                        pcmInfo.HardwareType != PcmType.P12 && pcmInfo.HardwareType != PcmType.E54)
-                    {
-                        var hardwareResponse = await Vehicle.QueryHardwareId();
-                        if (hardwareResponse.Status == ResponseStatus.Success)
-                            _logger.AddUserMessage($"Hardware ID: {hardwareResponse.Value}");
-                        else
-                            _logger.AddUserMessage($"Hardware ID query failed: {hardwareResponse.Status}");
-                    }
-
-                    // Disable Serial Number lookup for those that do not provide it
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.BlackBox)
-                    {
-                        var serialResponse = await Vehicle.QuerySerial();
-                        if (serialResponse.Status == ResponseStatus.Success)
-                            _logger.AddUserMessage($"Serial Number: {serialResponse.Value}");
-                        else
-                            _logger.AddUserMessage($"Serial Number query failed: {serialResponse.Status}");
-                    }
-
-                    // Disable BCC lookup for those that do not provide it
-                    if (pcmInfo != null && pcmInfo.HardwareType != PcmType.P04 &&
-                        pcmInfo.HardwareType != PcmType.P04_Early && pcmInfo.HardwareType != PcmType.P08)
-                    {
-                        var bccResponse = await Vehicle.QueryBCC();
-                        if (bccResponse.Status == ResponseStatus.Success)
-                            _logger.AddUserMessage($"Broad Cast Code: {bccResponse.Value}");
-                        else
-                            _logger.AddUserMessage($"BCC query failed: {bccResponse.Status}");
-                    }
-
-                    var mecResponse = await Vehicle.QueryMEC();
-                    if (mecResponse.Status == ResponseStatus.Success)
-                        _logger.AddUserMessage($"MEC: {mecResponse.Value}");
-                    else
-                        _logger.AddUserMessage($"MEC query failed: {mecResponse.Status}");
-
-                    var voltageResponse = await Vehicle.QueryVoltage();
-                    if (voltageResponse.Status == ResponseStatus.Success)
-                        _logger.AddUserMessage($"Voltage: {voltageResponse.Value}");
-                    else
-                        _logger.AddUserMessage($"Voltage query failed: {voltageResponse.Status}");
                 });
             }
             catch (Exception exception)
@@ -332,7 +293,7 @@ namespace PCMHammer.Viewmodels
             {
                 string warningMessage = "Canceling now could leave your PCM in an unbootable state (bricked)." + Environment.NewLine +
                                  "Are you absolutely sure you want to take that risk?";
-                bool proceedWithCancel = await PcmFlasher!.PromptForYesNo("PCM Hammer", warningMessage);
+                bool proceedWithCancel = await PcmFlasher!.PromptForYesNo(warningMessage, "PCM Hammer");
 
                 if (!proceedWithCancel)
                 {
@@ -365,10 +326,11 @@ namespace PCMHammer.Viewmodels
             };
             AddInitialLogMessages();
 
-            // Load up saved device and vehicle information from the settings file if configured to do so
-            bool retainConfigOnExit = Properties.Settings.Default.RetainDeviceConfigurationOnExit;
+            // Always reconnect to the last-used interface on startup (matching WinForms). The device is
+            // saved whenever one is picked; here we default straight back to it, falling back silently to
+            // the "no device" state if it can't be opened (e.g. unplugged).
             string savedType = Properties.Settings.Default.SavedDeviceType;
-            if (retainConfigOnExit && !string.IsNullOrEmpty(savedType))
+            if (!string.IsNullOrEmpty(savedType))
                 _ = TrySilentDeviceConnectionAsync();
         }
 
@@ -402,15 +364,12 @@ namespace PCMHammer.Viewmodels
             if (PcmReader == null) return;
             if (IsOperationRunning) return;
 
-            StatusText = "Preparing for Read...";
-
-            // Get save destination on the UI thread before calling Task.Run
-            string selectedFilePath = _fileDialogService.SaveBinFileDialog()!;
-
-            if (string.IsNullOrEmpty(selectedFilePath))
+            // Read into the in-memory working document (unsaved), the way WinForms does: no file is
+            // chosen up front. The user saves it via the prompt afterwards or the Save button, and Write
+            // flashes it directly - no file needed in between. Discard-check first so a fresh read never
+            // silently overwrites unsaved changes to the current document.
+            if (!ConfirmDiscardIfDirty())
             {
-                _logger.AddUserMessage("Read operation canceled by user (no file selected).");
-                StatusText = "Ready";
                 return;
             }
 
@@ -421,11 +380,20 @@ namespace PCMHammer.Viewmodels
                 _cancellationTokenSource = new CancellationTokenSource();
 
                 // Offload processing completely down to the Task Pool thread
-                bool success = await Task.Run(() =>
-                    PcmReader.ReadPcmAsync(selectedFilePath, useAutoPcmType, selectedPcmType, _cancellationTokenSource.Token)
+                PcmPackage? package = await Task.Run(() =>
+                    PcmReader.ReadToPackageAsync(useAutoPcmType, selectedPcmType, _cancellationTokenSource.Token)
                 );
 
-                StatusText = success ? "Read Completed Successfully!" : "Read Failed.";
+                if (package != null)
+                {
+                    SetLoadedPackage(package, path: null, dirty: true);
+                    StatusText = "Read Completed Successfully!";
+                    PromptSaveAfterRead();
+                }
+                else
+                {
+                    StatusText = "Read Failed.";
+                }
             }
             catch (Exception ex)
             {
@@ -470,25 +438,20 @@ namespace PCMHammer.Viewmodels
             if (PcmFlasher == null) return;
             if (IsOperationRunning) return;
 
-            bool useAutoPcmType = true;
+            // Verify compares the loaded working document against what is on the PCM - no file is picked.
+            PcmPackage? document = LoadedPackage;
+            if (document == null)
+            {
+                _logger.AddUserMessage("No file loaded. Read the PCM or load a file first.");
+                return;
+            }
+
             PcmTypeSelectDialogBox dialog = new() { Owner = Application.Current.MainWindow };
 
             if (dialog.ShowDialog() == true)
             {
-                useAutoPcmType = dialog.SelectedPCMType == PcmType.Undefined;
-                // Set appropriate status messages depending on the action type
-                StatusText = "Preparing for Comparison...";
-
-                // Get the source binary path safely on the UI thread before offloading
-                string selectedFilePath = _fileDialogService.OpenBinFileDialog()!;
-
-                if (string.IsNullOrEmpty(selectedFilePath))
-                {
-                    string cancelMessage = "Comparison canceled.";
-                    _logger.AddUserMessage(cancelMessage);
-                    StatusText = "Ready";
-                    return;
-                }
+                bool useAutoPcmType = dialog.SelectedPCMType == PcmType.Undefined;
+                PcmType forcedPcmType = useAutoPcmType ? PcmType.Undefined : dialog.SelectedPCMType;
 
                 try
                 {
@@ -496,21 +459,12 @@ namespace PCMHammer.Viewmodels
                     StatusText = "Comparing PCM Blocks...";
                     _cancellationTokenSource = new CancellationTokenSource();
 
-                    PcmType forcedPcmType = useAutoPcmType ? PcmType.Undefined : dialog.SelectedPCMType;
-
                     // Offload the low-level communication completely to the worker thread pool
                     bool success = await Task.Run(() =>
-                        PcmFlasher.WritePcmAsync(WriteType.Compare, selectedFilePath, useAutoPcmType, forcedPcmType, _cancellationTokenSource.Token)
+                        PcmFlasher.WritePackageAsync(WriteType.Compare, document, useAutoPcmType, forcedPcmType, _cancellationTokenSource.Token)
                     );
 
-                    if (success)
-                    {
-                        StatusText = "Comparison Complete!";
-                    }
-                    else
-                    {
-                        StatusText = "Comparison Found Differences or Failed.";
-                    }
+                    StatusText = success ? "Comparison Complete!" : "Comparison Found Differences or Failed.";
                 }
                 catch (Exception ex)
                 {
@@ -650,9 +604,8 @@ namespace PCMHammer.Viewmodels
         }
         private async Task<bool> TrySilentDeviceConnectionAsync()
         {
-            // Double check safety guards
-            if (!Properties.Settings.Default.RetainDeviceConfigurationOnExit ||
-                string.IsNullOrEmpty(Properties.Settings.Default.SavedDeviceType))
+            // Nothing to restore until a device has been picked at least once.
+            if (string.IsNullOrEmpty(Properties.Settings.Default.SavedDeviceType))
             {
                 return false;
             }
@@ -706,41 +659,34 @@ namespace PCMHammer.Viewmodels
             if (PcmFlasher == null) return;
             if (IsOperationRunning) return;
 
+            // Flash the in-memory working document; the bytes come from the loaded package, not a file.
+            PcmPackage? document = LoadedPackage;
+            if (document == null)
+            {
+                _logger.AddUserMessage("No file loaded. Read the PCM or load a file first.");
+                return;
+            }
+
             DelayDialogBox delayDialog = new() { Owner = Application.Current.MainWindow };
             StatusText = "Writing to PCM...";
 
             if (delayDialog.ShowDialog() == true)
             {
-                string selectedFilePath = _fileDialogService.OpenBinFileDialog()!;
-
-                if (string.IsNullOrEmpty(selectedFilePath))
-                {
-                    _logger.AddUserMessage("Flash operation canceled by user (no file selected).");
-                    StatusText = "Ready";
-                    return;
-                }
-
                 try
                 {
                     IsOperationRunning = true;
                     StatusText = "Writing to PCM...";
                     _cancellationTokenSource = new CancellationTokenSource();
 
-                    // Hand off the parameters directly to cleaned-up backend task
+                    _logger.AddUserMessage("Writing the loaded file" +
+                        (LoadedPackagePath != null ? " (" + Path.GetFileName(LoadedPackagePath) + ")" : string.Empty) + ".");
+
+                    bool useAutoPcmType = pcmType == PcmType.Undefined;
+
                     // Task.Run guarantees it completely leaves the UI thread.
-                    bool success = false;
-                    if (pcmType == PcmType.Undefined)
-                    {
-                        success = await Task.Run(() =>
-                            PcmFlasher.WritePcmAsync(writeType, selectedFilePath, useAutoPcmType: true, PcmType.Undefined, _cancellationTokenSource.Token, suppressOSIDWarning)
-                        );
-                    }
-                    else
-                    {
-                        success = await Task.Run(() =>
-                            PcmFlasher.WritePcmAsync(writeType, selectedFilePath, useAutoPcmType: false, pcmType, _cancellationTokenSource.Token)
-                        );
-                    }
+                    bool success = await Task.Run(() =>
+                        PcmFlasher.WritePackageAsync(writeType, document, useAutoPcmType, pcmType, _cancellationTokenSource.Token, suppressOSIDWarning)
+                    );
 
                     StatusText = success ? "Write Operation Completed." : "Write Operation Failed.";
                 }
@@ -775,7 +721,7 @@ namespace PCMHammer.Viewmodels
             {
                 string warningMessage = "Canceling now could leave your PCM in an unbootable state (bricked)." + Environment.NewLine +
                                  "Are you absolutely sure you want to take that risk?";
-                bool proceedWithCancel = await PcmFlasher!.PromptForYesNo("PCM Hammer", warningMessage);
+                bool proceedWithCancel = await PcmFlasher!.PromptForYesNo(warningMessage, "PCM Hammer");
 
                 if (!proceedWithCancel)
                 {
@@ -804,7 +750,10 @@ namespace PCMHammer.Viewmodels
                 _logger
             );
 
-            Vehicle = new Vehicle(workingDevice, protocolEngine, _logger, notifier, "PCMHammer")
+            // Empty base path: the library resolves kernels from AppContext.BaseDirectory (next to the
+            // exe, where BuildAll deploys them), matching WinForms. A literal here would look in a
+            // relative folder that doesn't exist and fail with "Invalid directory".
+            Vehicle = new Vehicle(workingDevice, protocolEngine, _logger, notifier, string.Empty)
             {
                 Enable4xReadWrite = Enable4xCom
             };
@@ -821,17 +770,23 @@ namespace PCMHammer.Viewmodels
         /// </summary>
         private void AddInitialLogMessages()
         {
+            // Version/build line comes from the shared AppInfo helper: a real "Version: x.y.z" for a
+            // stamped release build, or "Build: <date time>" for an untagged dev build (the assembly
+            // file version defaults to 0.0.0.0 in the csproj, and Generated.BuildTime is written at
+            // compile time by the Date target). This matches WinForms and the CLI.
+            string versionLine = AppInfo.GetVersionOrBuildLine(Generated.BuildTime);
+
             // Add user messages to the log
             _logger.AddUserMessage("PCM Hammer");
-            _logger.AddUserMessage("Copyright (C) 2018-2026 PcmHacking.net - GPL v3");
-            _logger.AddUserMessage("Version: 2.0.0");
-            _logger.AddUserMessage($"Running at: {DateTime.Now:dddd, MMMM d yyyy, HH:mm:ss}");
+            _logger.AddUserMessage(AppInfo.CopyrightNotice);
+            _logger.AddUserMessage(versionLine);
+            _logger.AddUserMessage(AppInfo.GetRunningAtMessage());
             _logger.AddUserMessage("Thanks for using PCM Hammer.");
             // Add debug messages to the debug log
             _logger.AddDebugMessage("PCM Hammer");
-            _logger.AddDebugMessage("Copyright (C) 2018-2026 PcmHacking.net - GPL v3");
-            _logger.AddDebugMessage("Version: 2.0.0");
-            _logger.AddDebugMessage($"Running at: {DateTime.Now:dddd, MMMM d yyyy, HH:mm:ss}");
+            _logger.AddDebugMessage(AppInfo.CopyrightNotice);
+            _logger.AddDebugMessage(versionLine);
+            _logger.AddDebugMessage(AppInfo.GetRunningAtMessage());
             _logger.AddDebugMessage("Thanks for using PCM Hammer.");
         }
 

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
@@ -17,7 +17,7 @@ namespace PCMHammer.Viewmodels
         private readonly FileDialogService _fileDialogService;
         private readonly Window _parentWindow;
         private CancellationTokenSource? _cancellationTokenSource;
-        private bool CanReInitialize() => SelectedDevice is not null; 
+        private bool CanReInitialize() => SelectedDevice is not null && !IsOperationRunning;
         #endregion
 
         #region Properties
@@ -82,6 +82,47 @@ namespace PCMHammer.Viewmodels
 
         #endregion
 
+        #region Command state
+
+        /// <summary>
+        /// Re-evaluate the CanExecute of every gated command. Called whenever the state those predicates
+        /// read (connected device, operation-running, loaded document) changes, so the bound menu items
+        /// and buttons enable/disable themselves - each command owns its rule and the views just reflect
+        /// it, instead of every view repeating an IsEnabled binding.
+        /// </summary>
+        private void RefreshCommandStates()
+        {
+            SelectDeviceCommand.NotifyCanExecuteChanged();
+            ReInitializeDeviceCommand.NotifyCanExecuteChanged();
+            LoadFileCommand.NotifyCanExecuteChanged();
+            SaveFileCommand.NotifyCanExecuteChanged();
+            SaveFileAsCommand.NotifyCanExecuteChanged();
+            ImportModuleCommand.NotifyCanExecuteChanged();
+            ExportBinCommand.NotifyCanExecuteChanged();
+            ReadPropertiesCommand.NotifyCanExecuteChanged();
+            ReadPCMCommand.NotifyCanExecuteChanged();
+            WritePCMCommand.NotifyCanExecuteChanged();
+            TestWriteCommand.NotifyCanExecuteChanged();
+            VerifyPCMCommand.NotifyCanExecuteChanged();
+            WriteParametersCommand.NotifyCanExecuteChanged();
+            WriteOSCalibrationBootCommand.NotifyCanExecuteChanged();
+            WriteFullFlashCloneCommand.NotifyCanExecuteChanged();
+            ChangeVINCommand.NotifyCanExecuteChanged();
+            TestFileChecksumsCommand.NotifyCanExecuteChanged();
+            BruteForceUnlockCommand.NotifyCanExecuteChanged();
+            HaltRunningKernelCommand.NotifyCanExecuteChanged();
+            UserDefinedKeyCommand.NotifyCanExecuteChanged();
+            CancelCurrentCommand.NotifyCanExecuteChanged();
+        }
+
+        // CommunityToolkit generates these hooks; each fires when its property changes. Refreshing the
+        // command states here keeps every command's enabled state current (see RefreshCommandStates).
+        partial void OnSelectedDeviceChanged(Device? value) => RefreshCommandStates();
+        partial void OnIsOperationRunningChanged(bool value) => RefreshCommandStates();
+        partial void OnLoadedPackageChanged(PcmPackage? value) => RefreshCommandStates();
+
+        #endregion
+
         #region Commands
         [RelayCommand]
         public async Task CopyLog(string logText)
@@ -109,29 +150,29 @@ namespace PCMHammer.Viewmodels
         #endregion
 
         #region Commands (Tools Menu & Operations)
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
         public async Task ReadPCM() => await ExecuteReadPCMAsync(true, PcmType.Undefined);
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task VerifyPCM() => await ExecuteVerificationAsync();
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
         public async Task ChangeVIN() => await ExecuteChangeVINAsync();
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task WriteParameters() => await ExecuteWritePCMAsync(WriteType.Parameters);
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task WriteOSCalibrationBoot() => await ExecuteWritePCMAsync(WriteType.OsPlusCalibrationPlusBoot);
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task WriteFullFlashClone() => await ExecuteWritePCMAsync(WriteType.Full);
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(IsDeviceControlEnabled))]
         public async Task TestFileChecksums() => await TestFileChecksumsAsync();
-        [RelayCommand]
-        public void BruteForceUnlock() 
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
+        public void BruteForceUnlock()
         {
             StatusText = "Brute Force Unlocking...";
             if (Vehicle == null) return;
             BruteForceDialogBox bruteForceDialog = new(vehicle: Vehicle, logger: _logger) { Owner = _parentWindow };
             StatusText = bruteForceDialog.ShowDialog() == true ? "Brute Force Unlock Completed." : "Ready";
         }
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
         public async Task HaltRunningKernel()
         {
             if (Vehicle == null) return;
@@ -181,8 +222,8 @@ namespace PCMHammer.Viewmodels
         #endregion
 
         #region Commands (Options Menu)
-        [RelayCommand]
-        public void UserDefinedKey() 
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
+        public void UserDefinedKey()
         {
             UserDefinedKeyDialogBox userDefinedKeyDialog = new() { Owner = _parentWindow };
             StatusText = "Setting user-defined key...";
@@ -205,8 +246,8 @@ namespace PCMHammer.Viewmodels
         #endregion
 
         #region Commands (Device & Operations Sidebar)
-        [RelayCommand]
-        public void SelectDevice() 
+        [RelayCommand(CanExecute = nameof(IsDeviceControlEnabled))]
+        public void SelectDevice()
         {
             var pickerDialog = new DevicePickerDialogBox(_logger) { Owner = _parentWindow };
             StatusText = "Selecting Device...";
@@ -246,8 +287,8 @@ namespace PCMHammer.Viewmodels
 
             StatusText = "Ready";
         }
-        [RelayCommand]
-        public async Task ReadProperties() 
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
+        public async Task ReadProperties()
         {
             StatusText = "Reading Properties...";
             if (Vehicle == null) return;
@@ -282,11 +323,11 @@ namespace PCMHammer.Viewmodels
                 StatusText = "Ready";
             }
         }
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task WritePCM() => await ExecuteWritePCMAsyncWithDialog();
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task TestWrite() => await ExecuteWritePCMAsync(WriteType.TestWrite);
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(IsOperationRunning))]
         public async Task CancelCurrent()
         {
             if (IsOperationRunning)
@@ -326,11 +367,11 @@ namespace PCMHammer.Viewmodels
             };
             AddInitialLogMessages();
 
-            // Always reconnect to the last-used interface on startup (matching WinForms). The device is
-            // saved whenever one is picked; here we default straight back to it, falling back silently to
-            // the "no device" state if it can't be opened (e.g. unplugged).
+            // Reconnect to the last-used interface on startup when the user has left that option on
+            // (the default). The device is saved whenever one is picked; here we default straight back
+            // to it, falling back silently to the "no device" state if it can't be opened (e.g. unplugged).
             string savedType = Properties.Settings.Default.SavedDeviceType;
-            if (!string.IsNullOrEmpty(savedType))
+            if (Properties.Settings.Default.RetainDeviceConfigurationOnExit && !string.IsNullOrEmpty(savedType))
                 _ = TrySilentDeviceConnectionAsync();
         }
 
@@ -354,6 +395,23 @@ namespace PCMHammer.Viewmodels
                 {
                     _logger.AddDebugMessage("One or more log save operations failed during application shutdown.");
                 }
+            }
+
+            // Release the hardware interface, the way WinForms disposes its Vehicle on close. Without
+            // this the J2534 device is never closed (PassThruDisconnect/PassThruClose never run), so it
+            // keeps its channel open and the next launch cannot reopen it - e.g. "failed to open
+            // ISO15765 (CAN) channel, error 0x1B". Vehicle.Dispose only closes the underlying device
+            // once its ShutdownSignalSource is cancelled (a reuse hook for the Uno front end), so signal
+            // that first.
+            try
+            {
+                Vehicle?.ShutdownSignalSource.Cancel();
+                Vehicle?.Dispose();
+                Vehicle = null;
+            }
+            catch (Exception exception)
+            {
+                _logger.AddDebugMessage("Device cleanup on shutdown failed: " + exception.Message);
             }
         }
 
@@ -604,8 +662,9 @@ namespace PCMHammer.Viewmodels
         }
         private async Task<bool> TrySilentDeviceConnectionAsync()
         {
-            // Nothing to restore until a device has been picked at least once.
-            if (string.IsNullOrEmpty(Properties.Settings.Default.SavedDeviceType))
+            // Respect the user's choice, and do nothing until a device has been picked at least once.
+            if (!Properties.Settings.Default.RetainDeviceConfigurationOnExit ||
+                string.IsNullOrEmpty(Properties.Settings.Default.SavedDeviceType))
             {
                 return false;
             }
@@ -640,7 +699,11 @@ namespace PCMHammer.Viewmodels
                         backgroundViewModel.Enable4xReadWrite
                     );
                     StatusText = "Ready";
-                    backgroundViewModel.AcceptCommand.Execute(null);
+
+                    // Do NOT call AcceptCommand here: it re-runs TestSelectedDeviceAsync, which opens a
+                    // SECOND device that is never wrapped or disposed (a leaked handle, and a second
+                    // PassThruOpen on the same J2534 hardware). The settings we are restoring from are
+                    // already saved, so there is nothing to persist.
                     return true;
                 }
             }
@@ -741,6 +804,24 @@ namespace PCMHammer.Viewmodels
         /// </summary>
         private void InitializeDeviceAndVehicle(Device workingDevice, bool Enable4xCom)
         {
+            // Release the previous interface when switching to a different device (Select Device), so its
+            // J2534 handle/channels don't leak for the rest of the session. A Re-Initialize reuses the
+            // same Device object, so skip disposal then - otherwise we'd close the very device the new
+            // Vehicle is about to wrap. Disposal needs the ShutdownSignalSource cancelled first (the Uno
+            // reuse hook), same as on app shutdown.
+            if (Vehicle != null && !ReferenceEquals(SelectedDevice, workingDevice))
+            {
+                try
+                {
+                    Vehicle.ShutdownSignalSource.Cancel();
+                    Vehicle.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    _logger.AddDebugMessage("Releasing previous device failed: " + exception.Message);
+                }
+            }
+
             SelectedDevice = workingDevice;
             Protocol protocolEngine = new();
 

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/SettingsViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/SettingsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PcmHacking;
 using PCMHammer.Helpers;
 using PCMHammer.Services;
 
@@ -18,9 +19,6 @@ namespace PCMHammer.Viewmodels
         public partial string LogDirectory { get; set; } = string.Empty;
 
         [ObservableProperty]
-        public partial bool RetainDeviceConfigurationOnExit { get; set; }
-
-        [ObservableProperty]
         public partial bool UseLogSaveAsDialog { get; set; }
 
         [ObservableProperty]
@@ -28,6 +26,17 @@ namespace PCMHammer.Viewmodels
 
         [ObservableProperty]
         public partial bool SaveDebugLogOnExit { get; set; }
+
+        // Advanced, per-session (RuntimeSettings) flags. These intentionally do not persist across
+        // launches - they reset to their defaults every time the app starts.
+        [ObservableProperty]
+        public partial bool AllowCrossFlashing { get; set; }
+
+        [ObservableProperty]
+        public partial bool ForceWriteAllSectors { get; set; }
+
+        [ObservableProperty]
+        public partial bool AllowModuleImport { get; set; }
         #endregion
 
         // Events
@@ -78,21 +87,29 @@ namespace PCMHammer.Viewmodels
         {
             BinDirectory = Properties.Settings.Default.BinDirectory;
             LogDirectory = Properties.Settings.Default.LogDirectory;
-            RetainDeviceConfigurationOnExit = Properties.Settings.Default.RetainDeviceConfigurationOnExit;
             UseLogSaveAsDialog = Properties.Settings.Default.UseLogSaveAsDialog;
             SaveResultsLogOnExit = Properties.Settings.Default.SaveResultsLogOnExit;
             SaveDebugLogOnExit = Properties.Settings.Default.SaveDebugLogOnExit;
+
+            // Per-session flags come from RuntimeSettings, not the persisted settings file.
+            AllowCrossFlashing = RuntimeSettings.AllowCrossFlashing;
+            ForceWriteAllSectors = RuntimeSettings.ForceWriteAllSectors;
+            AllowModuleImport = RuntimeSettings.AllowModuleImport;
         }
 
         public void SaveSettings()
         {
             Properties.Settings.Default.BinDirectory = BinDirectory; 
             Properties.Settings.Default.LogDirectory = LogDirectory;
-            Properties.Settings.Default.RetainDeviceConfigurationOnExit = RetainDeviceConfigurationOnExit;
             Properties.Settings.Default.UseLogSaveAsDialog = UseLogSaveAsDialog;
             Properties.Settings.Default.SaveResultsLogOnExit = SaveResultsLogOnExit;
             Properties.Settings.Default.SaveDebugLogOnExit = SaveDebugLogOnExit;
             Properties.Settings.Default.Save();
+
+            // Per-session flags: applied to RuntimeSettings, never written to disk.
+            RuntimeSettings.AllowCrossFlashing = AllowCrossFlashing;
+            RuntimeSettings.ForceWriteAllSectors = ForceWriteAllSectors;
+            RuntimeSettings.AllowModuleImport = AllowModuleImport;
         }
     }
 }

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/SettingsViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/SettingsViewModel.cs
@@ -19,6 +19,9 @@ namespace PCMHammer.Viewmodels
         public partial string LogDirectory { get; set; } = string.Empty;
 
         [ObservableProperty]
+        public partial bool AutoInitializeLastDevice { get; set; }
+
+        [ObservableProperty]
         public partial bool UseLogSaveAsDialog { get; set; }
 
         [ObservableProperty]
@@ -87,6 +90,7 @@ namespace PCMHammer.Viewmodels
         {
             BinDirectory = Properties.Settings.Default.BinDirectory;
             LogDirectory = Properties.Settings.Default.LogDirectory;
+            AutoInitializeLastDevice = Properties.Settings.Default.RetainDeviceConfigurationOnExit;
             UseLogSaveAsDialog = Properties.Settings.Default.UseLogSaveAsDialog;
             SaveResultsLogOnExit = Properties.Settings.Default.SaveResultsLogOnExit;
             SaveDebugLogOnExit = Properties.Settings.Default.SaveDebugLogOnExit;
@@ -99,8 +103,9 @@ namespace PCMHammer.Viewmodels
 
         public void SaveSettings()
         {
-            Properties.Settings.Default.BinDirectory = BinDirectory; 
+            Properties.Settings.Default.BinDirectory = BinDirectory;
             Properties.Settings.Default.LogDirectory = LogDirectory;
+            Properties.Settings.Default.RetainDeviceConfigurationOnExit = AutoInitializeLastDevice;
             Properties.Settings.Default.UseLogSaveAsDialog = UseLogSaveAsDialog;
             Properties.Settings.Default.SaveResultsLogOnExit = SaveResultsLogOnExit;
             Properties.Settings.Default.SaveDebugLogOnExit = SaveDebugLogOnExit;

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/ExportBinDialogBox.cs
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/ExportBinDialogBox.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using PcmHacking;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PCMHammer.Views.DialogBoxes
+{
+    /// <summary>One exportable image and the controller it belongs to.</summary>
+    public class ExportBinSelection
+    {
+        public required PackageController Controller { get; set; }
+        public required PackageImage Image { get; set; }
+    }
+
+    /// <summary>
+    /// Export Bin picker (WPF): lists the controllers in the loaded document and the image(s) inside each,
+    /// with a checkbox per exportable image. Defaults to the first main image. OK returns the checked
+    /// images (the caller writes each to its own .bin); Cancel returns nothing. Reference images (slave
+    /// modules whose bytes aren't in the local library) are listed but cannot be checked.
+    /// This mirrors the WinForms ExportBinDialogBox.
+    /// </summary>
+    public class ExportBinDialogBox : Window
+    {
+        private readonly List<(CheckBox Box, ExportBinSelection Selection)> rows = new();
+
+        public ExportBinDialogBox(PcmPackage package)
+        {
+            this.Title = "Export Bin";
+            this.Width = 420;
+            this.Height = 340;
+            this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            this.ResizeMode = ResizeMode.NoResize;
+            this.ShowInTaskbar = false;
+
+            Grid grid = new() { Margin = new Thickness(12) };
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            TextBlock prompt = new()
+            {
+                Text = "Choose the image(s) to export as raw .bin files:",
+                Margin = new Thickness(0, 0, 0, 8),
+            };
+            Grid.SetRow(prompt, 0);
+            grid.Children.Add(prompt);
+
+            StackPanel list = new();
+            CheckBox? firstMainBox = null;
+            foreach (PackageController controller in package.Controllers)
+            {
+                string module = controller.ModuleType ?? controller.Type ?? ("Controller " + controller.Id);
+                foreach (PackageImage image in controller.Images)
+                {
+                    // An embedded image exports its own bytes; a reference exports the local library copy,
+                    // when that file is present.
+                    bool embedded = image.Data != null;
+                    bool inLibrary = !embedded && SlaveLibrary.Find(image.FileName) != null;
+                    bool exportable = embedded || inLibrary;
+                    string suffix =
+                        embedded ? string.Empty :
+                        inLibrary ? "  (from local library)" :
+                        "  (by reference - not in local library)";
+
+                    CheckBox box = new()
+                    {
+                        Content = module + " / " + (image.Target ?? "image") + suffix,
+                        IsEnabled = exportable,
+                        Margin = new Thickness(0, 2, 0, 2),
+                    };
+                    var selection = new ExportBinSelection { Controller = controller, Image = image };
+                    this.rows.Add((box, selection));
+                    list.Children.Add(box);
+
+                    if (exportable)
+                    {
+                        this.HasExportableImages = true;
+                        if (firstMainBox == null &&
+                            string.Equals(image.Target, "main", StringComparison.OrdinalIgnoreCase))
+                        {
+                            firstMainBox = box;
+                        }
+                    }
+                }
+            }
+
+            if (firstMainBox != null)
+            {
+                firstMainBox.IsChecked = true;
+            }
+
+            ScrollViewer scroller = new()
+            {
+                Content = list,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                BorderThickness = new Thickness(1),
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                Padding = new Thickness(6),
+            };
+            Grid.SetRow(scroller, 1);
+            grid.Children.Add(scroller);
+
+            StackPanel buttons = new()
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 10, 0, 0),
+            };
+            Button saveAs = new() { Content = "Save As...", Width = 90, Margin = new Thickness(0, 0, 8, 0), IsDefault = true };
+            Button cancel = new() { Content = "Cancel", Width = 90, IsCancel = true };
+            saveAs.Click += (s, e) => { this.DialogResult = true; };
+            buttons.Children.Add(saveAs);
+            buttons.Children.Add(cancel);
+            Grid.SetRow(buttons, 2);
+            grid.Children.Add(buttons);
+
+            this.Content = grid;
+        }
+
+        /// <summary>True when at least one image in the package carries bytes that can be exported.</summary>
+        public bool HasExportableImages { get; private set; }
+
+        /// <summary>The checked, exportable images.</summary>
+        public List<ExportBinSelection> SelectedImages
+        {
+            get
+            {
+                var result = new List<ExportBinSelection>();
+                foreach (var (box, selection) in this.rows)
+                {
+                    if (box.IsEnabled && box.IsChecked == true)
+                    {
+                        result.Add(selection);
+                    }
+                }
+                return result;
+            }
+        }
+    }
+}

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/ModuleImportDialog.cs
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/ModuleImportDialog.cs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using Microsoft.Win32;
+using PcmHacking;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PCMHammer.Views.DialogBoxes
+{
+    /// <summary>
+    /// Module import (WPF), gated by the "Allow module import" setting. Lists the loaded package's image
+    /// slots (main plus any slave modules) with a Replace button on each, so a module can be swapped for a
+    /// file of matching size (slave) or format (main). Changes apply in place to the package;
+    /// <see cref="Changed"/> reports whether any were made. Mirrors the WinForms ModuleImportDialog.
+    /// </summary>
+    public class ModuleImportDialog : Window
+    {
+        private readonly PcmPackage package;
+        private readonly ILogger logger;
+
+        /// <summary>True when at least one slot was replaced.</summary>
+        public bool Changed { get; private set; }
+
+        public ModuleImportDialog(PcmPackage package, ILogger logger)
+        {
+            this.package = package;
+            this.logger = logger;
+
+            this.Title = "Import Module";
+            this.Width = 600;
+            this.Height = 380;
+            this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            this.ResizeMode = ResizeMode.NoResize;
+            this.ShowInTaskbar = false;
+
+            Grid grid = new() { Margin = new Thickness(12) };
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            TextBlock intro = new()
+            {
+                Text = "Replace a module with a file of the same size (slave) or format (main). This builds a file " +
+                       "with a specific module - use only if you know what you are doing.",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 8),
+            };
+            Grid.SetRow(intro, 0);
+            grid.Children.Add(intro);
+
+            StackPanel rowHost = new();
+            this.BuildRows(rowHost);
+
+            ScrollViewer scroller = new()
+            {
+                Content = rowHost,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                BorderThickness = new Thickness(1),
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                Padding = new Thickness(6),
+            };
+            Grid.SetRow(scroller, 1);
+            grid.Children.Add(scroller);
+
+            Button close = new()
+            {
+                Content = "Close",
+                Width = 90,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 10, 0, 0),
+                IsDefault = true,
+                IsCancel = true,
+            };
+            Grid.SetRow(close, 2);
+            grid.Children.Add(close);
+
+            this.Content = grid;
+        }
+
+        private void BuildRows(Panel host)
+        {
+            foreach (PackageController controller in this.package.Controllers)
+            {
+                TextBlock header = new()
+                {
+                    Text = string.Format("Controller {0} ({1})",
+                        controller.Id, controller.ModuleType ?? controller.Type ?? "PCM"),
+                    FontWeight = FontWeights.Bold,
+                    Margin = new Thickness(0, 6, 0, 4),
+                };
+                host.Children.Add(header);
+
+                foreach (PackageImage image in controller.Images)
+                {
+                    Grid row = new() { Margin = new Thickness(12, 2, 0, 2) };
+                    row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                    TextBlock detail = new()
+                    {
+                        Text = Describe(image),
+                        VerticalAlignment = VerticalAlignment.Center,
+                        TextWrapping = TextWrapping.Wrap,
+                    };
+                    Grid.SetColumn(detail, 0);
+                    row.Children.Add(detail);
+
+                    Button replace = new()
+                    {
+                        Content = "Replace...",
+                        Width = 100,
+                        Margin = new Thickness(8, 0, 0, 0),
+                    };
+                    PackageController capturedController = controller;
+                    PackageImage capturedImage = image;
+                    TextBlock capturedDetail = detail;
+                    replace.Click += (s, e) => this.ReplaceSlot(capturedController, capturedImage, capturedDetail);
+                    Grid.SetColumn(replace, 1);
+                    row.Children.Add(replace);
+
+                    host.Children.Add(row);
+                }
+            }
+        }
+
+        /// <summary>One-line description of a slot's current content: target, size, id, and source.</summary>
+        private static string Describe(PackageImage image)
+        {
+            string target = image.Target ?? "image";
+            long size = CurrentSize(image);
+            string sizeText = size > 0 ? FormatSize(size) : "size unknown";
+            string source =
+                image.Data != null ? "embedded" :
+                SlaveLibrary.Find(image.FileName) != null ? "from library" :
+                "reference, not in library";
+            string id =
+                image.Osid != null ? ", OSID " + image.Osid :
+                image.PartNumber != null ? ", p/n " + image.PartNumber :
+                string.Empty;
+            return string.Format("{0}: {1}{2} ({3})", target, sizeText, id, source);
+        }
+
+        private void ReplaceSlot(PackageController controller, PackageImage image, TextBlock detail)
+        {
+            bool isMain = string.Equals(image.Target, "main", StringComparison.OrdinalIgnoreCase);
+
+            string? path = this.PickFile();
+            if (path == null)
+            {
+                return;
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = File.ReadAllBytes(path);
+            }
+            catch (Exception exception)
+            {
+                this.Warn("Unable to open file: " + exception.Message);
+                return;
+            }
+
+            bool ok = isMain
+                ? this.ReplaceMain(controller, image, bytes, path)
+                : this.ReplaceSlave(image, bytes, path);
+            if (!ok)
+            {
+                return;
+            }
+
+            detail.Text = Describe(image);
+            this.Changed = true;
+        }
+
+        /// <summary>
+        /// Main slot: the file must be a valid image for this app (format gate) and match the controller's
+        /// module type. If the controller carries slave references bound to a different main OSID, warn.
+        /// </summary>
+        private bool ReplaceMain(PackageController controller, PackageImage image, byte[] bytes, string path)
+        {
+            FileValidator validator = new(bytes, this.logger);
+            if (!validator.IdentifyAndValidate())
+            {
+                this.Warn("This file is corrupt or its format is unknown to PCM Hammer. It was not imported.");
+                return false;
+            }
+
+            PcmType fileType = validator.GetFileType();
+            uint fileOsid = validator.GetOsidFromImage();
+
+            if (!string.IsNullOrEmpty(controller.ModuleType) &&
+                !string.Equals(fileType.ToString(), controller.ModuleType, StringComparison.OrdinalIgnoreCase))
+            {
+                this.Warn(string.Format(
+                    "This is a {0} image, but the controller is {1}. It was not imported.", fileType, controller.ModuleType));
+                return false;
+            }
+
+            bool hasSlave = controller.Images.Any(
+                i => i.Target != null && i.Target.StartsWith("slave", StringComparison.OrdinalIgnoreCase));
+            if (hasSlave && image.Osid != null && fileOsid != 0 && image.Osid != fileOsid)
+            {
+                MessageBoxResult choice = MessageBox.Show(this,
+                    string.Format(
+                        "The slave modules in this package were recorded for main OSID {0}, but this image is OSID {1}." + Environment.NewLine +
+                        "Writing this combination may produce a non-functional module." + Environment.NewLine + Environment.NewLine +
+                        "Import anyway?", image.Osid, fileOsid),
+                    "Possible slave mismatch", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (choice != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+            }
+
+            image.Data = bytes;
+            image.Osid = fileOsid != 0 ? fileOsid : (uint?)null;
+            this.logger.AddUserMessage(string.Format(
+                "Imported main from {0} (OSID {1}, {2}).", Path.GetFileName(path), fileOsid, new OSIDInfo(fileType).Description));
+            return true;
+        }
+
+        /// <summary>
+        /// Slave slot: we cannot yet validate slave content, so the gate is size - the file must match the
+        /// slot's current size (from its bytes or the local-library copy). If that size is unknown, confirm.
+        /// </summary>
+        private bool ReplaceSlave(PackageImage image, byte[] bytes, string path)
+        {
+            long expected = CurrentSize(image);
+            if (expected > 0 && bytes.LongLength != expected)
+            {
+                this.Warn(string.Format(
+                    "The {0} module is {1}; this file is {2}. Import a file of the same size.",
+                    image.Target, FormatSize(expected), FormatSize(bytes.LongLength)));
+                return false;
+            }
+
+            if (expected == 0)
+            {
+                MessageBoxResult choice = MessageBox.Show(this,
+                    string.Format(
+                        "The current size of \"{0}\" is unknown (it is not in the local library), so the file cannot be size-checked." + Environment.NewLine +
+                        "Import anyway?", image.Target),
+                    "Unverified size", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (choice != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+            }
+
+            image.Data = bytes;
+
+            // The imported file becomes this slot's content; reflect its name (and part number if the name
+            // is numeric, as factory slave modules are).
+            string name = Path.GetFileName(path);
+            image.FileName = name;
+            if (uint.TryParse(Path.GetFileNameWithoutExtension(path), out uint partNumber))
+            {
+                image.PartNumber = partNumber;
+            }
+
+            this.logger.AddUserMessage(string.Format(
+                "Imported {0} from {1} ({2}).", image.Target, name, FormatSize(bytes.LongLength)));
+            return true;
+        }
+
+        /// <summary>The slot's current size in bytes: its embedded bytes, else the local-library copy, else 0.</summary>
+        private static long CurrentSize(PackageImage image)
+        {
+            if (image.Data != null)
+            {
+                return image.Data.LongLength;
+            }
+
+            string? path = SlaveLibrary.Find(image.FileName);
+            return path != null ? new FileInfo(path).Length : 0;
+        }
+
+        private string? PickFile()
+        {
+            OpenFileDialog dialog = new()
+            {
+                DefaultExt = ".bin",
+                Filter = "Binary files (*.bin)|*.bin|All files (*.*)|*.*",
+                FilterIndex = 1,
+                RestoreDirectory = true,
+            };
+            if (!string.IsNullOrWhiteSpace(PCMHammer.Properties.Settings.Default.BinDirectory))
+            {
+                dialog.InitialDirectory = PCMHammer.Properties.Settings.Default.BinDirectory;
+            }
+            return dialog.ShowDialog(this) == true ? dialog.FileName : null;
+        }
+
+        private static string FormatSize(long bytes) =>
+            (bytes >= 1024 && bytes % 1024 == 0) ? (bytes / 1024) + " KiB" : bytes + " bytes";
+
+        private void Warn(string message)
+        {
+            this.logger.AddUserMessage(message);
+            MessageBox.Show(this, message, "Import Module", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+}

--- a/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:helpers="clr-namespace:PCMHammer.Helpers"
         mc:Ignorable="d"
         ThemeMode="System"
-        Title="PCM Hammer" Height="638" Width="800"
+        Title="{Binding WindowTitle}" Height="638" Width="800"
         Loaded="Window_Loaded"
         Closing="Window_Closing">
     <Grid>
@@ -18,6 +18,19 @@
         </Grid.RowDefinitions>
         <Menu>
             <MenuItem Header="_File">
+                <MenuItem Header="_Load File..."        Command="{Binding LoadFileCommand}"
+                          IsEnabled="{Binding IsDeviceControlEnabled}"/>
+                <MenuItem Header="_Save File..."        Command="{Binding SaveFileCommand}"
+                          IsEnabled="{Binding CanUseDocument}"/>
+                <MenuItem Header="Save File _As..."     Command="{Binding SaveFileAsCommand}"
+                          IsEnabled="{Binding CanUseDocument}"/>
+                <Separator/>
+                <MenuItem Header="_Import Bin..."       Command="{Binding ImportModuleCommand}"
+                          IsEnabled="{Binding CanUseDocument}"
+                          Visibility="{Binding IsModuleImportAllowed, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                <MenuItem Header="_Export Bin..."       Command="{Binding ExportBinCommand}"
+                          IsEnabled="{Binding CanUseDocument}"/>
+                <Separator/>
                 <MenuItem Header="Save _Results Log"    Command="{Binding SaveResultsLogCommand}"/>
                 <MenuItem Header="Save _Debug Log"      Command="{Binding SaveDebugLogCommand}"/>
                 <Separator/>
@@ -25,29 +38,30 @@
             </MenuItem>
             <MenuItem Header="_Tools">
                 <MenuItem Header="_Read Entire PCM" Command="{Binding ReadPCMCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanStartOperation}"/>
                 <MenuItem Header="_Verify Entire PCM" Command="{Binding VerifyPCMCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanWriteDocument}"/>
                 <MenuItem Header="_Change VIN" Command="{Binding ChangeVINCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanStartOperation}"/>
                 <Separator Height="2"/>
                 <MenuItem Header="Write _Parameters" Command="{Binding WriteParametersCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanWriteDocument}"/>
                 <MenuItem Header="Write _OS, Calibration &amp; Boot" Command="{Binding WriteOSCalibrationBootCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanWriteDocument}"/>
                 <MenuItem Header="Write _Full Flash (Clone)" Command="{Binding WriteFullFlashCloneCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanWriteDocument}"/>
                 <Separator Height="2"/>
-                <MenuItem Header="_Test File Checksums..." Command="{Binding TestFileChecksumsCommand}"/>
+                <MenuItem Header="_Test File Checksums..." Command="{Binding TestFileChecksumsCommand}"
+                          IsEnabled="{Binding IsDeviceControlEnabled}"/>
                 <MenuItem Header="Brute Force _Unlock..." Command="{Binding BruteForceUnlockCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanStartOperation}"/>
                 <Separator Height="2"/>
                 <MenuItem Header="_Halt Running Kernel" Command="{Binding HaltRunningKernelCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanStartOperation}"/>
             </MenuItem>
             <MenuItem Header="_Options">
                 <MenuItem Header="_User Defined Key" Command="{Binding UserDefinedKeyCommand}"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}"/>
+                          IsEnabled="{Binding CanStartOperation}"/>
                 <MenuItem Header="_Settings" Command="{Binding SettingsCommand}"/>
             </MenuItem>
         </Menu>
@@ -59,7 +73,7 @@
             </Grid.ColumnDefinitions>
 
             <StackPanel>
-                <GroupBox Header="Device">
+                <GroupBox Header="Device" IsEnabled="{Binding IsDeviceControlEnabled}">
                     <StackPanel>
                         <Button Content="_Select Device"   
                                 Command="{Binding SelectDeviceCommand}"
@@ -72,21 +86,33 @@
                                 Margin="0,0,0,5"/>
                     </StackPanel>
                 </GroupBox>
-                <GroupBox Header="Operations" Grid.Row="1" VerticalAlignment="Center"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}">
+                <GroupBox Header="File">
                     <StackPanel>
-                        <Button Content="Read _Properties"      Command="{Binding ReadPropertiesCommand}"   HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="Read P_CM"             Command="{Binding ReadPCMCommand}"          HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Write PCM"            Command="{Binding WritePCMCommand}"         HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="T_est Write"           Command="{Binding TestWriteCommand}"        HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Verify PCM"           Command="{Binding VerifyPCMCommand}"        HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Load File..."         Command="{Binding LoadFileCommand}"  IsEnabled="{Binding IsDeviceControlEnabled}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Save File..."         Command="{Binding SaveFileCommand}"  IsEnabled="{Binding CanUseDocument}"         HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="E_xport Bin..."        Command="{Binding ExportBinCommand}" IsEnabled="{Binding CanUseDocument}"         HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <TextBlock Text="{Binding LoadedFileText}" TextWrapping="Wrap" FontSize="11" Opacity="0.8" Margin="0,2,0,0"/>
                     </StackPanel>
                 </GroupBox>
-                <GroupBox Header="Kernel" Grid.Row="2"
-                          IsEnabled="{Binding SelectedDevice, Converter={StaticResource NullToBoolean}}">
+                <GroupBox Header="Operations" Grid.Row="1" VerticalAlignment="Center"
+                          IsEnabled="{Binding CanStartOperation}">
                     <StackPanel>
-                        <Button Content="_Halt Running Kernel"  Command="{Binding HaltRunningKernelCommand}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Cancel"               Command="{Binding CancelCurrentCommand}"     HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <!-- Read/Read Properties only need a connected device; Write/Test Write/Verify act
+                             on the loaded document, so they additionally require one (CanWriteDocument). -->
+                        <Button Content="Read _Properties"      Command="{Binding ReadPropertiesCommand}"   HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="Read P_CM"             Command="{Binding ReadPCMCommand}"          HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Write PCM"            Command="{Binding WritePCMCommand}"         IsEnabled="{Binding CanWriteDocument}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="T_est Write"           Command="{Binding TestWriteCommand}"        IsEnabled="{Binding CanWriteDocument}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Verify PCM"           Command="{Binding VerifyPCMCommand}"        IsEnabled="{Binding CanWriteDocument}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                    </StackPanel>
+                </GroupBox>
+                <GroupBox Header="Kernel" Grid.Row="2">
+                    <StackPanel>
+                        <!-- Halt is a normal operation (needs a device, only when idle); Cancel is the
+                             opposite - it exists to interrupt a running operation, so it is enabled
+                             only while one is running. -->
+                        <Button Content="_Halt Running Kernel"  Command="{Binding HaltRunningKernelCommand}" IsEnabled="{Binding CanStartOperation}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Cancel"               Command="{Binding CancelCurrentCommand}"     IsEnabled="{Binding IsOperationRunning}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
@@ -18,18 +18,13 @@
         </Grid.RowDefinitions>
         <Menu>
             <MenuItem Header="_File">
-                <MenuItem Header="_Load File..."        Command="{Binding LoadFileCommand}"
-                          IsEnabled="{Binding IsDeviceControlEnabled}"/>
-                <MenuItem Header="_Save File..."        Command="{Binding SaveFileCommand}"
-                          IsEnabled="{Binding CanUseDocument}"/>
-                <MenuItem Header="Save File _As..."     Command="{Binding SaveFileAsCommand}"
-                          IsEnabled="{Binding CanUseDocument}"/>
+                <MenuItem Header="_Load File..."        Command="{Binding LoadFileCommand}"/>
+                <MenuItem Header="_Save File..."        Command="{Binding SaveFileCommand}"/>
+                <MenuItem Header="Save File _As..."     Command="{Binding SaveFileAsCommand}"/>
                 <Separator/>
                 <MenuItem Header="_Import Bin..."       Command="{Binding ImportModuleCommand}"
-                          IsEnabled="{Binding CanUseDocument}"
                           Visibility="{Binding IsModuleImportAllowed, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                <MenuItem Header="_Export Bin..."       Command="{Binding ExportBinCommand}"
-                          IsEnabled="{Binding CanUseDocument}"/>
+                <MenuItem Header="_Export Bin..."       Command="{Binding ExportBinCommand}"/>
                 <Separator/>
                 <MenuItem Header="Save _Results Log"    Command="{Binding SaveResultsLogCommand}"/>
                 <MenuItem Header="Save _Debug Log"      Command="{Binding SaveDebugLogCommand}"/>
@@ -37,31 +32,21 @@
                 <MenuItem Header="E_xit"                Command="{Binding ExitCommand}"/>
             </MenuItem>
             <MenuItem Header="_Tools">
-                <MenuItem Header="_Read Entire PCM" Command="{Binding ReadPCMCommand}"
-                          IsEnabled="{Binding CanStartOperation}"/>
-                <MenuItem Header="_Verify Entire PCM" Command="{Binding VerifyPCMCommand}"
-                          IsEnabled="{Binding CanWriteDocument}"/>
-                <MenuItem Header="_Change VIN" Command="{Binding ChangeVINCommand}"
-                          IsEnabled="{Binding CanStartOperation}"/>
+                <MenuItem Header="_Read Entire PCM" Command="{Binding ReadPCMCommand}"/>
+                <MenuItem Header="_Verify Entire PCM" Command="{Binding VerifyPCMCommand}"/>
+                <MenuItem Header="_Change VIN" Command="{Binding ChangeVINCommand}"/>
                 <Separator Height="2"/>
-                <MenuItem Header="Write _Parameters" Command="{Binding WriteParametersCommand}"
-                          IsEnabled="{Binding CanWriteDocument}"/>
-                <MenuItem Header="Write _OS, Calibration &amp; Boot" Command="{Binding WriteOSCalibrationBootCommand}"
-                          IsEnabled="{Binding CanWriteDocument}"/>
-                <MenuItem Header="Write _Full Flash (Clone)" Command="{Binding WriteFullFlashCloneCommand}"
-                          IsEnabled="{Binding CanWriteDocument}"/>
+                <MenuItem Header="Write _Parameters" Command="{Binding WriteParametersCommand}"/>
+                <MenuItem Header="Write _OS, Calibration &amp; Boot" Command="{Binding WriteOSCalibrationBootCommand}"/>
+                <MenuItem Header="Write _Full Flash (Clone)" Command="{Binding WriteFullFlashCloneCommand}"/>
                 <Separator Height="2"/>
-                <MenuItem Header="_Test File Checksums..." Command="{Binding TestFileChecksumsCommand}"
-                          IsEnabled="{Binding IsDeviceControlEnabled}"/>
-                <MenuItem Header="Brute Force _Unlock..." Command="{Binding BruteForceUnlockCommand}"
-                          IsEnabled="{Binding CanStartOperation}"/>
+                <MenuItem Header="_Test File Checksums..." Command="{Binding TestFileChecksumsCommand}"/>
+                <MenuItem Header="Brute Force _Unlock..." Command="{Binding BruteForceUnlockCommand}"/>
                 <Separator Height="2"/>
-                <MenuItem Header="_Halt Running Kernel" Command="{Binding HaltRunningKernelCommand}"
-                          IsEnabled="{Binding CanStartOperation}"/>
+                <MenuItem Header="_Halt Running Kernel" Command="{Binding HaltRunningKernelCommand}"/>
             </MenuItem>
             <MenuItem Header="_Options">
-                <MenuItem Header="_User Defined Key" Command="{Binding UserDefinedKeyCommand}"
-                          IsEnabled="{Binding CanStartOperation}"/>
+                <MenuItem Header="_User Defined Key" Command="{Binding UserDefinedKeyCommand}"/>
                 <MenuItem Header="_Settings" Command="{Binding SettingsCommand}"/>
             </MenuItem>
         </Menu>
@@ -73,46 +58,45 @@
             </Grid.ColumnDefinitions>
 
             <StackPanel>
-                <GroupBox Header="Device" IsEnabled="{Binding IsDeviceControlEnabled}">
+                <GroupBox Header="Device">
                     <StackPanel>
-                        <Button Content="_Select Device"   
+                        <Button Content="_Select Device"
                                 Command="{Binding SelectDeviceCommand}"
                                 CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
                                 HorizontalAlignment="Stretch"
                                 Margin="0,0,0,5"/>
-                        <Button Content="Re-_Initialize Device" 
-                                Command="{Binding ReInitializeDeviceCommand}" 
+                        <Button Content="Re-_Initialize Device"
+                                Command="{Binding ReInitializeDeviceCommand}"
                                 HorizontalAlignment="Stretch"
                                 Margin="0,0,0,5"/>
                     </StackPanel>
                 </GroupBox>
                 <GroupBox Header="File">
                     <StackPanel>
-                        <Button Content="_Load File..."         Command="{Binding LoadFileCommand}"  IsEnabled="{Binding IsDeviceControlEnabled}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Save File..."         Command="{Binding SaveFileCommand}"  IsEnabled="{Binding CanUseDocument}"         HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="E_xport Bin..."        Command="{Binding ExportBinCommand}" IsEnabled="{Binding CanUseDocument}"         HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Load File..."         Command="{Binding LoadFileCommand}"  HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Save File..."         Command="{Binding SaveFileCommand}"  HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="E_xport Bin..."        Command="{Binding ExportBinCommand}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
                         <TextBlock Text="{Binding LoadedFileText}" TextWrapping="Wrap" FontSize="11" Opacity="0.8" Margin="0,2,0,0"/>
                     </StackPanel>
                 </GroupBox>
-                <GroupBox Header="Operations" Grid.Row="1" VerticalAlignment="Center"
-                          IsEnabled="{Binding CanStartOperation}">
+                <GroupBox Header="Operations" Grid.Row="1" VerticalAlignment="Center">
                     <StackPanel>
-                        <!-- Read/Read Properties only need a connected device; Write/Test Write/Verify act
-                             on the loaded document, so they additionally require one (CanWriteDocument). -->
+                        <!-- Enablement is owned by each command's CanExecute: Read/Read Properties need a
+                             connected device (CanStartOperation); Write/Test Write/Verify additionally
+                             need a loaded document (CanWriteDocument). -->
                         <Button Content="Read _Properties"      Command="{Binding ReadPropertiesCommand}"   HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
                         <Button Content="Read P_CM"             Command="{Binding ReadPCMCommand}"          HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Write PCM"            Command="{Binding WritePCMCommand}"         IsEnabled="{Binding CanWriteDocument}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="T_est Write"           Command="{Binding TestWriteCommand}"        IsEnabled="{Binding CanWriteDocument}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Verify PCM"           Command="{Binding VerifyPCMCommand}"        IsEnabled="{Binding CanWriteDocument}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Write PCM"            Command="{Binding WritePCMCommand}"         HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="T_est Write"           Command="{Binding TestWriteCommand}"        HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Verify PCM"           Command="{Binding VerifyPCMCommand}"        HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
                     </StackPanel>
                 </GroupBox>
                 <GroupBox Header="Kernel" Grid.Row="2">
                     <StackPanel>
-                        <!-- Halt is a normal operation (needs a device, only when idle); Cancel is the
-                             opposite - it exists to interrupt a running operation, so it is enabled
-                             only while one is running. -->
-                        <Button Content="_Halt Running Kernel"  Command="{Binding HaltRunningKernelCommand}" IsEnabled="{Binding CanStartOperation}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
-                        <Button Content="_Cancel"               Command="{Binding CancelCurrentCommand}"     IsEnabled="{Binding IsOperationRunning}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <!-- Halt is a normal operation (CanStartOperation); Cancel is the opposite - its
+                             CanExecute is IsOperationRunning, so it is enabled only while one is running. -->
+                        <Button Content="_Halt Running Kernel"  Command="{Binding HaltRunningKernelCommand}" HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
+                        <Button Content="_Cancel"               Command="{Binding CancelCurrentCommand}"     HorizontalAlignment="Stretch" Margin="0,0,0,5"/>
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml.cs
+++ b/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml.cs
@@ -33,6 +33,14 @@ namespace PCMHammer
             // Stop the window from closing immediately
             e.Cancel = true;
 
+            // Offer to save a modified working document before we tear anything down. If the user cancels,
+            // abort the close entirely and leave the app as it was.
+            if (_viewModel is not null && !_viewModel.ConfirmDiscardOnExit())
+            {
+                _viewModel.StatusText = "Ready";
+                return;
+            }
+
             if (_viewModel is not null)
             {
                 _viewModel.StatusText = "Saving logs and cleaning up hardware connections...";

--- a/Apps/UI/WPF/PCMHammer/Views/SettingsWindow.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/SettingsWindow.xaml
@@ -10,13 +10,6 @@
         WindowStartupLocation="CenterOwner"
         Title="Settings" Width="629">
     <StackPanel Margin="16">
-        <GroupBox Header="Device">
-            <StackPanel>
-                <CheckBox Content="Retain device configuration" IsChecked="{Binding RetainDeviceConfigurationOnExit}"/>
-                <TextBlock FontStyle="Oblique" Opacity="0.5" Text="This will retain the current device configuration (serial, port, and device or J2354) on exit."/>
-            </StackPanel>
-        </GroupBox>
-
         <GroupBox Header="Bin Files">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -44,6 +37,16 @@
                 <TextBlock FontStyle="Oblique" Opacity="0.5" Text="Automatically save the results log on application exit."/>
                 <CheckBox Content="Save debug log on application exit" IsChecked="{Binding SaveDebugLogOnExit}"/>
                 <TextBlock FontStyle="Oblique" Opacity="0.5" Text="Automatically save the debug log on application exit."/>
+            </StackPanel>
+        </GroupBox>
+        <GroupBox Header="Advanced (this session only)">
+            <StackPanel>
+                <CheckBox Content="Allow cross-flashing" IsChecked="{Binding AllowCrossFlashing}"/>
+                <TextBlock FontStyle="Oblique" Opacity="0.5" TextWrapping="Wrap" Text="Relax the file-vs-PCM compatibility checks so an incompatible image can be written. Advanced recovery only - this can brick a PCM."/>
+                <CheckBox Content="Force write all sectors" IsChecked="{Binding ForceWriteAllSectors}"/>
+                <TextBlock FontStyle="Oblique" Opacity="0.5" TextWrapping="Wrap" Text="Erase and rewrite every in-scope sector even when its CRC already matches. Slower, adds flash wear; useful for recovery."/>
+                <CheckBox Content="Allow module import" IsChecked="{Binding AllowModuleImport}"/>
+                <TextBlock FontStyle="Oblique" Opacity="0.5" TextWrapping="Wrap" Text="Show File -&gt; Import Bin, which replaces one module of the loaded package. For building a file with a specific slave module."/>
             </StackPanel>
         </GroupBox>
         <Grid Margin="0,16,0,0" HorizontalAlignment="Right">

--- a/Apps/UI/WPF/PCMHammer/Views/SettingsWindow.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/SettingsWindow.xaml
@@ -10,6 +10,13 @@
         WindowStartupLocation="CenterOwner"
         Title="Settings" Width="629">
     <StackPanel Margin="16">
+        <GroupBox Header="Device">
+            <StackPanel>
+                <CheckBox Content="Reconnect to the last used interface on startup" IsChecked="{Binding AutoInitializeLastDevice}"/>
+                <TextBlock FontStyle="Oblique" Opacity="0.5" TextWrapping="Wrap" Text="On launch, automatically re-open the interface you last used (serial port + device, or J2534). Turn off to always start with no interface selected."/>
+            </StackPanel>
+        </GroupBox>
+
         <GroupBox Header="Bin Files">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
@@ -1444,115 +1444,19 @@ namespace PcmHacking
             try
             {
                 this.DisableUserInput();
-                DetectedModule? pcm = await this.Vehicle.DetectAndSelectPcm(CancellationToken.None);
-                if (pcm == null)
+
+                // One shared flow detects the bus (VPW or CAN) and reads the identification; the UI
+                // only logs what it returns.
+                PcmIdentity? identity = await this.Vehicle.ReadIdentity(CancellationToken.None);
+                if (identity == null)
                 {
                     this.AddUserMessage("No PCM detected.");
                     return;
                 }
 
-                this.AddUserMessage("Detected PCM on " + pcm.Bus.ToString());
-
-                if (pcm.Bus != BusProtocol.Vpw)
+                foreach (string line in identity.Lines)
                 {
-                    this.AddUserMessage("PCM Identification:");
-                    foreach (string line in await CanIdentification.Read(this.Vehicle.CreateCanCommands(), CancellationToken.None))
-                    {
-                        this.AddUserMessage(line);
-                    }
-                    return;
-                }
-
-                OSIDInfo pcmInfo = new OSIDInfo(pcm.Osid);
-                this.AddUserMessage("OSID: " + pcm.Osid.ToString());
-                this.AddUserMessage("Description: " + pcmInfo.Description);
-
-                var vinResponse = await this.Vehicle.QueryVin();
-                if (vinResponse.Status == ResponseStatus.Success)
-                {
-                    this.AddUserMessage("VIN: " + vinResponse.Value);
-                }
-                else
-                {
-                    this.AddUserMessage("VIN query failed: " + vinResponse.Status.ToString());
-                }
-
-                // Disable Calibration ID lookup for those that do not provide it
-                if (pcmInfo.HardwareType != PcmType.BlackBox)
-                {
-
-                    var calResponse = await this.Vehicle.QueryCalibrationId();
-                    if (calResponse.Status == ResponseStatus.Success)
-                    {
-                        this.AddUserMessage("Calibration ID: " + calResponse.Value.ToString());
-                    }
-                    else
-                    {
-                        this.AddUserMessage("Calibration ID query failed: " + calResponse.Status.ToString());
-                    }
-                }
-
-                // Disable HardwareID lookup for the P05, P10, P12 and E54.
-                if (pcmInfo.HardwareType != PcmType.P05 && pcmInfo.HardwareType != PcmType.P05b && pcmInfo.HardwareType != PcmType.P10 && pcmInfo.HardwareType != PcmType.P12 && pcmInfo.HardwareType != PcmType.E54)
-                {
-                    var hardwareResponse = await this.Vehicle.QueryHardwareId();
-                    if (hardwareResponse.Status == ResponseStatus.Success)
-                    {
-                        this.AddUserMessage("Hardware ID: " + hardwareResponse.Value.ToString());
-                    }
-                    else
-                    {
-                        this.AddUserMessage("Hardware ID query failed: " + hardwareResponse.Status.ToString());
-                    }
-                }
-
-                // Disable Serial Number lookup for those that do not provide it
-                if (pcmInfo.HardwareType != PcmType.BlackBox)
-                {
-                    var serialResponse = await this.Vehicle.QuerySerial();
-
-                    if (serialResponse.Status == ResponseStatus.Success)
-                    {
-                        this.AddUserMessage("Serial Number: " + serialResponse.Value.ToString());
-                    }
-                    else
-                    {
-                        this.AddUserMessage("Serial Number query failed: " + serialResponse.Status.ToString());
-                    }
-                }
-
-                // Disable BCC lookup for those that do not provide it
-                if (pcmInfo.HardwareType != PcmType.P04 && pcmInfo.HardwareType != PcmType.P04_Early && pcmInfo.HardwareType != PcmType.P08)
-                {
-                    var bccResponse = await this.Vehicle.QueryBCC();
-                    if (bccResponse.Status == ResponseStatus.Success)
-                    {
-                        this.AddUserMessage("Broad Cast Code: " + bccResponse.Value.ToString());
-                    }
-                    else
-                    {
-                        this.AddUserMessage("BCC query failed: " + bccResponse.Status.ToString());
-                    }
-                }
-
-                var mecResponse = await this.Vehicle.QueryMEC();
-                if (mecResponse.Status == ResponseStatus.Success)
-                {
-                    this.AddUserMessage("MEC: " + mecResponse.Value.ToString());
-                }
-                else
-                {
-                    this.AddUserMessage("MEC query failed: " + mecResponse.Status.ToString());
-                }
-
-                var voltageResponse = await this.Vehicle.QueryVoltage();
-                if (voltageResponse.Status == ResponseStatus.Success)
-                {
-                    this.AddUserMessage("Voltage: " + voltageResponse.Value.ToString());
-                }
-                else
-                {
-                    this.AddUserMessage("Voltage query failed: " + voltageResponse.Status.ToString());
+                    this.AddUserMessage(line);
                 }
             }
             catch (Exception exception)

--- a/Kernels/BuildAll.cmd
+++ b/Kernels/BuildAll.cmd
@@ -119,9 +119,12 @@ call :CopyToDetectedLinuxTargets
 rem Uno targets (detected by output folder patterns)
 call :CopyToDetectedUnoTargets
 
-rem WPF targets
-call :CopyBinsToTarget "..\Apps\UI\WPF\PCMHammer\bin\Debug\net10.0-windows"
-call :CopyBinsToTarget "..\Apps\UI\WPF\PCMHammer\bin\Release\net10.0-windows"
+rem WPF targets. The app can build to bin\Debug\net10.0-windows or, when built for the x86
+rem platform, bin\x86\Debug\net10.0-windows, so scan for the app binary wherever it landed
+rem (same approach as Uno). Create the default Debug output dir so a fresh checkout (not yet
+rem built) still receives the kernels.
+call :CopyBinsToTarget "..\Apps\UI\WPF\PCMHammer\bin\Debug\net10.0-windows" create
+call :CopyToDetectedWpfTargets
 
 if "%COPY_TARGET_COUNT%" == "0" (
   echo No output targets detected. Kernels remain in build\.
@@ -139,6 +142,21 @@ if not exist "%LINUX_BIN_ROOT%" (
 echo Scanning Linux CLI bin output targets for the app binary...
 for /r "%LINUX_BIN_ROOT%" %%F in (pcmhammer-cli.dll) do (
   echo   Found Linux CLI output: "%%~dpF"
+  call :CopyBinsToTarget "%%~dpF"
+)
+
+goto :EOF
+
+:CopyToDetectedWpfTargets
+set "WPF_BIN_ROOT=..\Apps\UI\WPF\PCMHammer\bin"
+if not exist "%WPF_BIN_ROOT%" (
+  echo WPF bin root not found: "%WPF_BIN_ROOT%"
+  goto :EOF
+)
+
+echo Scanning WPF bin output targets for the app binary...
+for /r "%WPF_BIN_ROOT%" %%F in (pcm*.exe) do (
+  echo   Found WPF output: "%%~dpF"
   call :CopyBinsToTarget "%%~dpF"
 )
 


### PR DESCRIPTION
- Add the "loaded file" document model to the WPF UI (WinForms parity): Load/Save/Save As for .phz and .bin, read-to-document with save prompt, Write/Test Write/Verify operate on the loaded document, plus Export Bin and (dev-gated) Module Import dialogs and Advanced runtime-flag settings.
- Grey out operation buttons while a read/write/verify runs; Cancel is enabled only during one.
- Fix transfer-rate display (parse "Kbps" regardless of case).
- Show a build date for untagged dev builds via AppInfo/Generated.BuildTime instead of a hardcoded version.
- Always reconnect to the last-used interface on startup; drop the now-redundant "retain device configuration" toggle.
- Fix Yes/No warning prompts that were read as abort: run synchronously so the result is read after the user answers, and correct the (message,title) argument order.
- Fix "Invalid directory" kernel load: pass an empty base path so kernels resolve next to the exe.
- CLI: route --identify-pcm through the shared Vehicle.ReadIdentity instead of a duplicated identify implementation.