### PR TITLE
Anuts/wpf improvements

### DIFF
--- a/.github/workflows/CheckBuild.yml
+++ b/.github/workflows/CheckBuild.yml
@@ -11,6 +11,7 @@
 # 2026-06-18 - Antus <pcmhacking.net> E38 PPC Kernel, via source or binary distribution
 # 2026-08-11 - Antus <pcmhacking.net> Delete the temp kernels artifact in its own job, after
 #                                     all consumers, instead of racing them from Applications
+# 2026-08-21 - Antus <pcmhacking.net> Add the WPF front end as an experimental, dev-only build
 #
 
 name: CheckBuild
@@ -351,6 +352,7 @@ jobs:
       # at runtime via $GITHUB_ENV before the upload steps reference them.
       WINFORMS_ARTIFACT_SUFFIX: ''
       UNO_ARTIFACT_SUFFIX: ''
+      WPF_ARTIFACT_SUFFIX: ''
       CLI_ARTIFACT_SUFFIX: ''
       PACKAGE_TOKEN: ''
 
@@ -466,19 +468,45 @@ jobs:
         -p:AndroidPackageFormat=apk
         -p:EmbedAssembliesIntoApk=true
 
+    # The WPF front end is experimental and dev-only, on the same footing as Uno: skipped
+    # entirely on a release tag so it cannot be attached to (or block) the release, and
+    # published only as an experimental workflow artifact on normal pushes/PRs. The same
+    # gate is applied to every WPF build/stage/upload step below.
+    #
+    # Published self-contained and single-file, like the Linux CLI: the artifact is one .exe
+    # that needs no .NET install, with the kernels embedded in it (see PCMHammer.csproj), so
+    # there are no loose .bin files to keep beside it. win-x86 because the app must be 32-bit
+    # to load 32-bit J2534 driver DLLs. dotnet publish is enough here (unlike the WinForms
+    # apps, which need msbuild for Costura) because this is an SDK-style project.
+    - name: Publish WPF Windows (self-contained, single-file)
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      shell: pwsh
+      run: |
+        # The csproj embeds whatever is in Kernels\build; the CI kernels artifact was
+        # downloaded to TemporaryArtifactStorage\Kernels, so place them where it expects.
+        # (The WinForms step above does the same - repeated here so this step does not
+        # silently depend on that one having run first and produced an embeddable set.)
+        New-Item -ItemType Directory -Force -Path Kernels/build | Out-Null
+        Copy-Item -Path "TemporaryArtifactStorage/Kernels/*.bin" -Destination "Kernels/build" -Force
+        dotnet publish Apps/UI/WPF/PCMHammer/PCMHammer.csproj -c Release -r win-x86
+
     - name: Compute artifact names
       shell: pwsh
       run: |
         # WinForms + CLI artifacts are named after the git tag on a release (e.g. v2.0.0);
-        # development builds use a UTC stamp + branch name. The Uno (experimental) artifacts
-        # take their version from the Uno csproj (set by Release.ps1).
+        # development builds use a UTC stamp + branch name. The Uno and WPF (experimental)
+        # artifacts take their version from their own csproj (set by Release.ps1).
         [xml]$uno = Get-Content "Apps/UI/UnoUI/PcmHacking.UnoUI/PcmHacking.UnoUI.csproj"
         $unoDisplay = ($uno.Project.PropertyGroup | Where-Object { $_.ApplicationDisplayVersion } | Select-Object -First 1).ApplicationDisplayVersion
         $unoVersion = ($uno.Project.PropertyGroup | Where-Object { $_.ApplicationVersion } | Select-Object -First 1).ApplicationVersion
 
+        [xml]$wpf = Get-Content "Apps/UI/WPF/PCMHammer/PCMHammer.csproj"
+        $wpfVersion = ($wpf.Project.PropertyGroup | Where-Object { $_.Version } | Select-Object -First 1).Version
+
         $isReleaseTag = ($env:IS_RELEASE_TAG -eq "True")
         $timestampUtc = [DateTime]::UtcNow.ToString("yyyyMMdd_HHmmss")
         $unoLooksUnversioned = ($unoDisplay -eq "0.0.0.0")
+        $wpfLooksUnversioned = ($wpfVersion -eq "0.0.0.0")
         $branchNameRaw = if ([string]::IsNullOrWhiteSpace($env:GITHUB_HEAD_REF)) { $env:GITHUB_REF_NAME } else { $env:GITHUB_HEAD_REF }
         $branchNameSafe = $branchNameRaw -replace '[\\/]', '-'
         $branchNameSafe = $branchNameSafe -replace '[^A-Za-z0-9._-]', '-'
@@ -497,6 +525,12 @@ jobs:
           $unoArtifactSuffix = $devSuffix
         }
 
+        if ($isReleaseTag -and -not $wpfLooksUnversioned -and -not [string]::IsNullOrWhiteSpace($wpfVersion)) {
+          $wpfArtifactSuffix = "v$wpfVersion"
+        } else {
+          $wpfArtifactSuffix = $devSuffix
+        }
+
         # CLI shares the same version as WinForms since they are built from the same codebase.
         $cliArtifactSuffix = $winFormsArtifactSuffix
 
@@ -504,6 +538,7 @@ jobs:
         "UNO_APP_VERSION=$unoVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "WINFORMS_ARTIFACT_SUFFIX=$winFormsArtifactSuffix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "UNO_ARTIFACT_SUFFIX=$unoArtifactSuffix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "WPF_ARTIFACT_SUFFIX=$wpfArtifactSuffix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "CLI_ARTIFACT_SUFFIX=$cliArtifactSuffix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Stage Uno Windows artifact payload
@@ -592,6 +627,29 @@ jobs:
           Copy-Item -Path $apk.FullName -Destination "TemporaryArtifactStorage/UnoAndroid" -Force
         }
 
+    - name: Stage WPF Windows artifact payload
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      shell: pwsh
+      run: |
+        # The kernels are embedded in the executable, so the artifact is just the single
+        # self-contained exe - no loose .bin files needed alongside it. PCMHammer.dll.config
+        # carries the Settings defaults and is copied too; it is tiny and harmless.
+        $pub = "Apps/UI/WPF/PCMHammer/bin/Release/net10.0-windows/win-x86/publish"
+        if (!(Test-Path "$pub/PCMHammer.exe")) {
+          throw "WPF single-file output not found at $pub/PCMHammer.exe"
+        }
+
+        New-Item -ItemType Directory -Force -Path TemporaryArtifactStorage/WPF | Out-Null
+        Copy-Item -Path "$pub/*" -Destination "TemporaryArtifactStorage/WPF" -Recurse -Force
+
+        # A single-file build that quietly lost its embedded kernels would look fine here and
+        # only fail against a vehicle, so fail the build instead.
+        $exeSizeMb = [math]::Round((Get-Item "$pub/PCMHammer.exe").Length / 1MB, 1)
+        Write-Host "WPF single-file exe: $exeSizeMb MB"
+        if ($exeSizeMb -lt 40) {
+          throw "WPF exe is only $exeSizeMb MB - expected ~59 MB self-contained; the bundle looks incomplete."
+        }
+
     # --- Package the WinForms apps into the installer + portable, in this same job, so
     #     no redundant intermediate (raw WinForms/CLI) artifacts are published.
     #     PACKAGE_TOKEN / PACKAGE_APP_VERSION are set by the
@@ -612,7 +670,7 @@ jobs:
           -StagingRoot $staging -OutputName "PCMHammer_$($env:PACKAGE_TOKEN)_Portable" -OutputDir $dist
 
     # GitHub lists run artifacts alphabetically: Linux_CLI (from the LinuxCLI job), then
-    # Portable, Setup, Uno_Android, Uno_Windows.
+    # Portable, Setup, Uno_Android, Uno_Windows, WPF_Windows.
     - name: Upload installer artifact
       uses: actions/upload-artifact@v7
       with:
@@ -644,9 +702,16 @@ jobs:
         name: PCMHammer_Uno_Windows_experimental_${{ env.UNO_ARTIFACT_SUFFIX }}_${{ github.sha }}
         path: TemporaryArtifactStorage/UnoWindows
 
+    - name: Upload WPF Windows artifact (experimental)
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: PCMHammer_WPF_Windows_experimental_${{ env.WPF_ARTIFACT_SUFFIX }}_${{ github.sha }}
+        path: TemporaryArtifactStorage/WPF
+
     # On an x.x.x / x.x.x.x tag push, publish a GitHub Release and attach the WinForms
-    # installer + portable zip (the public, supported downloads). The Uno targets are
-    # experimental and are intentionally NOT attached - they remain only as workflow
+    # installer + portable zip (the public, supported downloads). The Uno and WPF targets
+    # are experimental and are intentionally NOT attached - they remain only as workflow
     # run-artifacts above. Re-running on an existing tag updates the assets in place.
     - name: Publish GitHub Release
       if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/CheckBuild.yml
+++ b/.github/workflows/CheckBuild.yml
@@ -10,7 +10,7 @@
 # 2026-04-10 - Antus <pcmhacking.net> Update for WinForms + Uno Windows + Uno Android
 # 2026-06-18 - Antus <pcmhacking.net> E38 PPC Kernel, via source or binary distribution
 # 2026-08-11 - Antus <pcmhacking.net> Delete the temp kernels artifact in its own job, after
-#                                     all consumers, instead of racing them from Applications
+#                                     all consumers, instead of racing them from the app jobs
 # 2026-08-21 - Antus <pcmhacking.net> Add the WPF front end as an experimental, dev-only build
 #
 
@@ -222,11 +222,12 @@ jobs:
         name: Temp_Kernels_${{github.sha}}
         path: TemporaryArtifactStorage
 
-  # Linux command-line build. Runs on Linux (the WinForms/CLI/Uno-Windows builds need
-  # Windows, so they live in the Applications job); this one only needs .NET and the
-  # kernels artifact. Publishes a self-contained, single-file binary named "pcmhammer-cli"
-  # with the kernels embedded in it, and uploads that single binary as the artifact.
-  LinuxCLI:
+  # Everything built on Linux. Currently the command-line build: the WinForms/CLI/WPF/Uno-Windows
+  # builds need Windows, so they live in the WindowsApps job, while this one only needs .NET and the
+  # kernels artifact. Publishes a self-contained, single-file binary named "pcmhammer-cli" with the
+  # kernels embedded in it, and uploads that single binary as the artifact.
+  LinuxApps:
+    name: Linux Apps
     needs: Kernels
     runs-on: ubuntu-24.04
     env:
@@ -335,7 +336,7 @@ jobs:
         path: TemporaryArtifactStorage/LinuxCLI
 
     # On a release tag, attach the binary to the GitHub Release so it is a public download
-    # rather than a login-only workflow artifact. The Applications job publishes the same
+    # rather than a login-only workflow artifact. The WindowsApps job publishes the same
     # release with the Windows assets; whichever job gets there first creates it and the
     # other uploads into it, so this is written to tolerate either order.
     - name: Publish Linux CLI to GitHub Release
@@ -357,7 +358,7 @@ jobs:
         if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
           gh release upload "$TAG" "$asset" --clobber --repo "$GITHUB_REPOSITORY"
         else
-          # Create it; if the Applications job created it in between, fall back to uploading.
+          # Create it; if the WindowsApps job created it in between, fall back to uploading.
           gh release create "$TAG" "$asset" \
             --repo "$GITHUB_REPOSITORY" \
             --title "PCM Hammer $TAG" \
@@ -365,7 +366,10 @@ jobs:
           || gh release upload "$TAG" "$asset" --clobber --repo "$GITHUB_REPOSITORY"
         fi
 
-  Applications:
+  # Everything built on Windows: the WinForms apps, the Windows CLI, the installer/portable
+  # packages, and the experimental WPF and Uno targets.
+  WindowsApps:
+    name: Windows Apps
     needs: Kernels
     runs-on: windows-2025-vs2026
 
@@ -692,7 +696,7 @@ jobs:
         & "Apps/build/Build-Portable.ps1" `
           -StagingRoot $staging -OutputName "PCMHammer_$($env:PACKAGE_TOKEN)_Portable" -OutputDir $dist
 
-    # GitHub lists run artifacts alphabetically: Linux_CLI (from the LinuxCLI job), then
+    # GitHub lists run artifacts alphabetically: Linux_CLI (from the LinuxApps job), then
     # Portable, Setup, Uno_Android, Uno_Windows, WPF_Windows.
     - name: Upload installer artifact
       uses: actions/upload-artifact@v7
@@ -775,7 +779,7 @@ jobs:
   # This job deliberately does not fail the run - a leftover temp artifact expires on its
   # own and is not worth turning a good build red over.
   CleanupKernelsArtifact:
-    needs: [ Kernels, LinuxCLI, Applications ]
+    needs: [ Kernels, LinuxApps, WindowsApps ]
     if: always()
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/CheckBuild.yml
+++ b/.github/workflows/CheckBuild.yml
@@ -16,7 +16,30 @@
 
 name: CheckBuild
 
-on: [ pull_request, push ]
+# Push is filtered to the branches we merge INTO, plus tags; every other branch is covered by
+# pull_request. Without the filter a push to a branch with an open PR fired both events and built
+# the whole thing twice. Dropping the push run loses nothing: pull_request builds the MERGE commit
+# (the branch already merged into its base), which is the more meaningful result, while push builds
+# the branch tip in isolation.
+#
+# Note the trade-off: a branch with no PR open gets no CI. Open a draft PR to get builds from the
+# first push.
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - 'Release/**'
+    tags:
+      - '**'          # release tags must keep firing - see "Publish GitHub Release" below
+  pull_request:
+
+# One run per branch/PR: a new push supersedes the build still running for the previous one, instead
+# of leaving several full builds (kernels + WinForms + WPF + Uno + installer) racing to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Never cancel a release build partway through.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 permissions:
   contents: write   # needed to create a GitHub Release on x.x.x.x / x.x.x tags

--- a/Apps/PcmLibrary/CKernelWriter.cs
+++ b/Apps/PcmLibrary/CKernelWriter.cs
@@ -35,6 +35,10 @@ namespace PcmHacking
         // in Write(). Normally the detected chip size, not the (possibly smaller) PCM-type default.
         private UInt32 effectiveImageSize;
 
+        // Set from RuntimeSettings at the start of Write() and cleared once the forced pass has run,
+        // so a retry does not force again. Mirrors CanKernelWriter.
+        private bool forceWriteAllSectorsPending;
+
         public CKernelWriter(Vehicle vehicle, OSIDInfo pcmInfo, Protocol protocol, WriteType writeType, ILogger logger)
         {
             this.vehicle = vehicle;
@@ -304,6 +308,8 @@ namespace PcmHacking
                 this.effectiveImageSize,
                 this.logger);
 
+            this.forceWriteAllSectorsPending = RuntimeSettings.ForceWriteAllSectors;
+
             bool allRangesMatch = false;
             int messageRetryCount = 0;
             await this.vehicle.SendToolPresentNotification();
@@ -334,7 +340,7 @@ namespace PcmHacking
                             logger.AddUserMessage("Beginning test.");
                         }
                     }
-                    else
+                    else if (!this.forceWriteAllSectorsPending)
                     {
                         logger.AddUserMessage("All relevant ranges are identical.");
                         if (attempt > 1)
@@ -365,10 +371,25 @@ namespace PcmHacking
                 // does not allow boot-sector writes and boot would be written.
                 if (!this.IsWritePlanAllowedByPcmInfo(flashChip, relevantBlocks))
                 {
-                    logger.AddUserMessage("Boot sector write is required for this operation.");
-                    logger.AddUserMessage($"Abort: The {this.pcmInfo.HardwareType} boot sector is write protected. This PCM is not compatible with this file.");
+                    foreach (string line in WritePlan.DescribeBootSectorAbort(
+                        this.pcmInfo.HardwareType, this.forceWriteAllSectorsPending))
+                    {
+                        logger.AddUserMessage(line);
+                    }
+
                     await this.vehicle.Cleanup();
                     return false;
+                }
+
+                if (WritePlan.ForcedPlanExcludesBoot(
+                        this.writeType,
+                        this.pcmInfo.IsSupportedWriteBootSector,
+                        relevantBlocks,
+                        this.effectiveImageSize,
+                        flashChip.MemoryRanges,
+                        this.forceWriteAllSectorsPending))
+                {
+                    logger.AddUserMessage(WritePlan.DescribeBootExclusion(this.pcmInfo.HardwareType));
                 }
 
                 // Erase and rewrite the required memory ranges.
@@ -438,6 +459,9 @@ namespace PcmHacking
                         bytesRemaining -= range.Size;
                     }
                 }
+
+                // The forced full-write pass, if any, is now done.
+                this.forceWriteAllSectorsPending = false;
             }
 
             if (allRangesMatch)
@@ -506,10 +530,9 @@ namespace PcmHacking
         private bool ShouldProcess(MemoryRange range, BlockType relevantBlocks)
         {
             // One shared rule for "will this range be written", used by the boot-sector gate too.
-            // The VPW path has never honoured RuntimeSettings.ForceWriteAllSectors (only the CAN
-            // writer implements it), so force is false here.
             return WritePlan.ShouldProcessRange(
-                range, relevantBlocks, this.writeType, this.effectiveImageSize, forceAllSectors: false);
+                range, relevantBlocks, this.writeType, this.effectiveImageSize,
+                this.forceWriteAllSectorsPending, this.pcmInfo.IsSupportedWriteBootSector);
         }
 
         /// <summary>
@@ -525,7 +548,7 @@ namespace PcmHacking
                 relevantBlocks,
                 this.effectiveImageSize,
                 flashChip.MemoryRanges,
-                forceAllSectors: false);
+                this.forceWriteAllSectorsPending);
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/CKernelWriter.cs
+++ b/Apps/PcmLibrary/CKernelWriter.cs
@@ -505,27 +505,11 @@ namespace PcmHacking
 
         private bool ShouldProcess(MemoryRange range, BlockType relevantBlocks)
         {
-            if ((range.ActualCrc == range.DesiredCrc) && (this.writeType != WriteType.TestWrite))
-            {
-                return false;
-            }
-
-            // The P10 has the same flash chip as the P59, but the high bit of the address bus
-            // isn't connected, so there will be hardware errors talking to the top 512kb.
-            // So, we skip ranges that are beyond the size of the usable image. For most PCMs the
-            // usable size is the whole detected chip; for P10/P11 it is the smaller PCM-type size.
-            if (range.Address >= this.effectiveImageSize)
-            {
-                return false;
-            }
-
-            // Skip irrelevant blocks.
-            if ((range.Type & relevantBlocks) == 0)
-            {
-                return false;
-            }
-
-            return true;
+            // One shared rule for "will this range be written", used by the boot-sector gate too.
+            // The VPW path has never honoured RuntimeSettings.ForceWriteAllSectors (only the CAN
+            // writer implements it), so force is false here.
+            return WritePlan.ShouldProcessRange(
+                range, relevantBlocks, this.writeType, this.effectiveImageSize, forceAllSectors: false);
         }
 
         /// <summary>
@@ -533,34 +517,15 @@ namespace PcmHacking
         /// </summary>
         private bool IsWritePlanAllowedByPcmInfo(FlashChip flashChip, BlockType relevantBlocks)
         {
-            // Compare and test-write are non-destructive.
-            if (this.writeType == WriteType.Compare || this.writeType == WriteType.TestWrite)
-            {
-                return true;
-            }
-
-            // Boot sector writes are supported; allow all write plans.
-            if (this.pcmInfo.IsSupportedWriteBootSector)
-            {
-                return true;
-            }
-
-            foreach (MemoryRange range in flashChip.MemoryRanges)
-            {
-                // ShouldProcess means this range is relevant AND differs (for real writes).
-                if (!this.ShouldProcess(range, relevantBlocks))
-                {
-                    continue;
-                }
-
-                // Block attempts to write boot sector on PCMs that do not support it
-                if ((range.Type & BlockType.Boot) != 0)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            // Shared with the CAN writer: a PCM that cannot write boot may still be cloned, as long
+            // as the plan does not actually write a boot range.
+            return WritePlan.BootPolicyAllowsWritePlan(
+                this.writeType,
+                this.pcmInfo.IsSupportedWriteBootSector,
+                relevantBlocks,
+                this.effectiveImageSize,
+                flashChip.MemoryRanges,
+                forceAllSectors: false);
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/CanKernelWriter.cs
+++ b/Apps/PcmLibrary/CanKernelWriter.cs
@@ -492,103 +492,63 @@ namespace PcmHacking
         /// </summary>
         private bool IsWritePlanAllowedByPcmInfo(FlashChip flashChip, BlockType relevantBlocks)
         {
+            // Pass the SAME force flag the write loop (ShouldProcess) uses. Without it a forced full
+            // write passes this gate by CRC and then writes boot anyway - a hard brick on a PCM whose
+            // boot sector cannot be rewritten.
             return BootPolicyAllowsWritePlan(
                 this.writeType,
                 this.pcmInfo.IsSupportedWriteBootSector,
                 relevantBlocks,
                 this.effectiveImageSize,
-                flashChip.MemoryRanges);
+                flashChip.MemoryRanges,
+                this.forceWriteAllSectorsPending);
         }
 
         /// <summary>
         /// Pure boot-sector write policy. Returns false only when a destructive plan on a PCM that
         /// cannot write its boot sector would erase/write a boot range whose content differs.
         /// </summary>
+        /// <summary>
+        /// Whether the PCM's boot-sector policy permits this write plan. Delegates to the shared
+        /// <see cref="WritePlan"/>; see there for why the force flag must be passed through.
+        /// </summary>
         public static bool BootPolicyAllowsWritePlan(
             WriteType writeType,
             bool supportsBootSectorWrite,
             BlockType relevantBlocks,
             UInt32 effectiveImageSize,
-            IEnumerable<MemoryRange> memoryRanges)
+            IEnumerable<MemoryRange> memoryRanges,
+            bool forceAllSectors = false)
         {
-            // Compare and test-write are non-destructive.
-            if (writeType == WriteType.Compare || writeType == WriteType.TestWrite)
-            {
-                return true;
-            }
-
-            // Boot sector writes are supported; allow all write plans.
-            if (supportsBootSectorWrite)
-            {
-                return true;
-            }
-
-            foreach (MemoryRange range in memoryRanges)
-            {
-                // A range is processed only when it is relevant AND differs (for real writes).
-                if (!ShouldProcessRange(range, relevantBlocks, writeType, effectiveImageSize))
-                {
-                    continue;
-                }
-
-                // Block attempts to write the boot sector on PCMs that do not support it.
-                if ((range.Type & BlockType.Boot) != 0)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return WritePlan.BootPolicyAllowsWritePlan(
+                writeType, supportsBootSectorWrite, relevantBlocks, effectiveImageSize,
+                memoryRanges, forceAllSectors);
         }
 
         private bool ShouldProcess(MemoryRange range, BlockType relevantBlocks)
         {
-            // A forced full-write pass includes every in-scope sector regardless of CRC. Otherwise
-            // defer to the normal rule, which skips sectors whose on-device CRC already matches.
-            if (!this.forceWriteAllSectorsPending)
-            {
-                return ShouldProcessRange(range, relevantBlocks, this.writeType, this.effectiveImageSize);
-            }
-
-            if (range.Address >= this.effectiveImageSize)
-            {
-                return false;
-            }
-
-            if ((range.Type & relevantBlocks) == 0)
-            {
-                return false;
-            }
-
-            return true;
+            // One shared rule for "will this range be written", used by the boot-sector gate too.
+            return WritePlan.ShouldProcessRange(
+                range, relevantBlocks, this.writeType, this.effectiveImageSize, this.forceWriteAllSectorsPending);
         }
 
         /// <summary>
         /// Pure form of <see cref="ShouldProcess"/>: a range is processed when it is in scope, within
         /// the image, and (for real writes) its on-device CRC differs from the image.
         /// </summary>
+        /// <summary>
+        /// Whether this range will be erased/written. Delegates to the shared <see cref="WritePlan"/>
+        /// so the boot-sector gate and the write loop can never disagree.
+        /// </summary>
         public static bool ShouldProcessRange(
             MemoryRange range,
             BlockType relevantBlocks,
             WriteType writeType,
-            UInt32 effectiveImageSize)
+            UInt32 effectiveImageSize,
+            bool forceAllSectors = false)
         {
-            if ((range.ActualCrc == range.DesiredCrc) && (writeType != WriteType.TestWrite))
-            {
-                return false;
-            }
-
-            if (range.Address >= effectiveImageSize)
-            {
-                return false;
-            }
-
-            if ((range.Type & relevantBlocks) == 0)
-            {
-                return false;
-            }
-
-            return true;
+            return WritePlan.ShouldProcessRange(
+                range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors);
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/CanKernelWriter.cs
+++ b/Apps/PcmLibrary/CanKernelWriter.cs
@@ -283,10 +283,11 @@ namespace PcmHacking
                 // boot-sector writes and the plan would write boot.
                 if (!this.IsWritePlanAllowedByPcmInfo(flashChip, relevantBlocks))
                 {
-                    logger.AddUserMessage("Boot sector write is required for this operation.");
-                    logger.AddUserMessage($"Abort: The {this.pcmInfo.HardwareType} boot sector is write protected. This PCM is not compatible with this file.");
+                    this.ReportBootSectorAbort();
                     return false;
                 }
+
+                this.ReportBootExcludedFromForcedPlan(flashChip, relevantBlocks);
 
                 // Erase and rewrite the required memory ranges.
                 DateTime startTime = DateTime.Now;
@@ -525,30 +526,58 @@ namespace PcmHacking
                 memoryRanges, forceAllSectors);
         }
 
+        /// <summary>Report why a write was refused by the boot-sector policy.</summary>
+        private void ReportBootSectorAbort()
+        {
+            foreach (string line in WritePlan.DescribeBootSectorAbort(
+                this.pcmInfo.HardwareType, this.forceWriteAllSectorsPending))
+            {
+                logger.AddUserMessage(line);
+            }
+        }
+
+        /// <summary>Tell the user when a forced pass is proceeding with the boot sector left out.</summary>
+        private void ReportBootExcludedFromForcedPlan(FlashChip flashChip, BlockType relevantBlocks)
+        {
+            if (WritePlan.ForcedPlanExcludesBoot(
+                    this.writeType,
+                    this.pcmInfo.IsSupportedWriteBootSector,
+                    relevantBlocks,
+                    this.effectiveImageSize,
+                    flashChip.MemoryRanges,
+                    this.forceWriteAllSectorsPending))
+            {
+                logger.AddUserMessage(WritePlan.DescribeBootExclusion(this.pcmInfo.HardwareType));
+            }
+        }
+
         private bool ShouldProcess(MemoryRange range, BlockType relevantBlocks)
         {
             // One shared rule for "will this range be written", used by the boot-sector gate too.
             return WritePlan.ShouldProcessRange(
-                range, relevantBlocks, this.writeType, this.effectiveImageSize, this.forceWriteAllSectorsPending);
+                range, relevantBlocks, this.writeType, this.effectiveImageSize,
+                this.forceWriteAllSectorsPending, this.pcmInfo.IsSupportedWriteBootSector);
         }
 
-        /// <summary>
-        /// Pure form of <see cref="ShouldProcess"/>: a range is processed when it is in scope, within
-        /// the image, and (for real writes) its on-device CRC differs from the image.
-        /// </summary>
         /// <summary>
         /// Whether this range will be erased/written. Delegates to the shared <see cref="WritePlan"/>
         /// so the boot-sector gate and the write loop can never disagree.
         /// </summary>
+        /// <remarks>
+        /// <paramref name="supportsBootSectorWrite"/> has no default on purpose: it changes the answer
+        /// for a forced boot range, and a silently-defaulted capability flag is exactly how the gate
+        /// and the loop drifted apart before.
+        /// </remarks>
         public static bool ShouldProcessRange(
             MemoryRange range,
             BlockType relevantBlocks,
             WriteType writeType,
             UInt32 effectiveImageSize,
-            bool forceAllSectors = false)
+            bool forceAllSectors,
+            bool supportsBootSectorWrite)
         {
             return WritePlan.ShouldProcessRange(
-                range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors);
+                range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors, supportsBootSectorWrite);
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/Messages/Protocol.Misc.cs
+++ b/Apps/PcmLibrary/Messages/Protocol.Misc.cs
@@ -89,15 +89,5 @@ namespace PcmHacking
             return new Message(bytes);
         }
 
-        public Response<bool> ParseRecoveryModeBroadcast(Message message)
-        {
-            Response<bool> rc = DoSimpleValidation(message, Priority.Physical0, 0x62, 0x01);
-            if (!rc.Value)
-            {
-                rc = DoSimpleValidation(message, Priority.Physical0, 0x62, 0x00);
-            }
-
-            return rc;
-        }        
     }
 }

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -515,7 +515,6 @@ namespace PcmHacking
                     this.IsSupportedWriteSlaveCPU = false;
                     this.IsSupportedWriteBySegment = false;
                     this.IsSupportedWriteBootSector = true; // tested on bench, boot sector write successful.
-                    this.IsUnderDevelopment = true;
                     this.BusProtocol = BusProtocol.Can500k;
                     this.GMLANProtocol = GMLANProtocol.P05c;
                     this.LoaderRequired = false;

--- a/Apps/PcmLibrary/Misc/RecoveryMode.cs
+++ b/Apps/PcmLibrary/Misc/RecoveryMode.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-only
+namespace PcmHacking
+{
+    /// <summary>
+    /// Shared rules for the explicit "PCM Recovery" operations, used by every UI so recovery behaves
+    /// the same everywhere.
+    /// </summary>
+    /// <remarks>
+    /// A PCM in recovery mode (its boot/reset pin grounded at power-up) sits in its resident boot
+    /// loader and answers no operating-system query, so nothing can be auto-detected. The user tells
+    /// us which PCM it is and we go straight in: no OSID query, no kernel probe, no bus detection.
+    /// That is exactly what the forced-PCM-type path in <see cref="ReadManager"/> and
+    /// <see cref="WriteManager"/> already does, so recovery simply forces the selected type.
+    /// <para>
+    /// We deliberately do NOT probe for recovery mode first. Detection is unreliable - it has only
+    /// ever been confirmed on ObdLink ScanTool hardware, and other interfaces never see the reply -
+    /// so a negative result would block the very rescue the user came here for.
+    /// </para>
+    /// </remarks>
+    public static class RecoveryMode
+    {
+        /// <summary>
+        /// Whether a recovery operation can be attempted for this PCM type. When false,
+        /// <paramref name="reason"/> is a user-facing explanation.
+        /// </summary>
+        public static bool CanAttempt(PcmType type, out string reason)
+        {
+            if (type == PcmType.Undefined)
+            {
+                reason = "Select the PCM type to recover. Recovery cannot auto-detect it, because a PCM "
+                    + "in recovery mode does not report its operating system.";
+                return false;
+            }
+
+            OSIDInfo info = new OSIDInfo(type);
+
+            // CAN recovery is not implemented yet. Say so plainly rather than starting a VPW flow on a
+            // CAN PCM, which would simply time out.
+            if (info.BusProtocol == BusProtocol.Can500k)
+            {
+                reason = $"Recovery is not yet supported for {type} (CAN bus). Only VPW PCMs can be recovered.";
+                return false;
+            }
+
+            if (!info.IsSupported)
+            {
+                reason = $"The {type} PCM is not supported.";
+                return false;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        /// <summary>The log line announcing that a recovery operation is starting.</summary>
+        public static string DescribeEntry(PcmType type, bool isWrite)
+        {
+            return $"PCM Recovery: entering recovery {(isWrite ? "write" : "read")} for a {type} PCM. "
+                + "Detection is skipped - the selected PCM type is used as-is.";
+        }
+    }
+}

--- a/Apps/PcmLibrary/Misc/WritePlan.cs
+++ b/Apps/PcmLibrary/Misc/WritePlan.cs
@@ -25,12 +25,17 @@ namespace PcmHacking
         /// on-device CRC already matches the image. Scope (image size and relevant block types) is
         /// still honoured: forcing rewrites more sectors, it never widens what is in scope.
         /// </param>
+        /// <param name="supportsBootSectorWrite">
+        /// Whether this PCM can rewrite its boot sector. When it cannot, forcing never applies to a
+        /// boot range: see the remarks on <see cref="BootPolicyAllowsWritePlan"/>.
+        /// </param>
         public static bool ShouldProcessRange(
             MemoryRange range,
             BlockType relevantBlocks,
             WriteType writeType,
             UInt32 effectiveImageSize,
-            bool forceAllSectors)
+            bool forceAllSectors,
+            bool supportsBootSectorWrite)
         {
             // Out of scope for this image. The P10 has the same flash chip as the P59, but the high
             // bit of the address bus isn't connected, so talking to the top 512kb is a hardware
@@ -47,8 +52,14 @@ namespace PcmHacking
                 return false;
             }
 
-            // A forced pass includes every in-scope sector regardless of CRC.
-            if (forceAllSectors)
+            // A forced pass includes every in-scope sector regardless of CRC - except a boot range on
+            // a PCM that cannot rewrite boot. Erasing boot only to write back identical bytes buys
+            // nothing and can brick some pcms (allow erase, fail write), others fail erase.
+            // such a range is judged on CRC alone: identical boot drops out of the plan and the write
+            // proceeds with every other sector forced, while differing boot stays in the plan so
+            // BootPolicyAllowsWritePlan can refuse the operation before anything is erased.
+            bool unwritableBoot = (range.Type & BlockType.Boot) != 0 && !supportsBootSectorWrite;
+            if (forceAllSectors && !unwritableBoot)
             {
                 return true;
             }
@@ -96,12 +107,14 @@ namespace PcmHacking
 
             foreach (MemoryRange range in memoryRanges)
             {
-                if (!ShouldProcessRange(range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors))
+                if (!ShouldProcessRange(range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors, supportsBootSectorWrite))
                 {
                     continue;
                 }
 
-                // This plan would erase/write boot on a PCM that cannot rewrite it.
+                // Boot is still in the plan, which (given ShouldProcessRange excludes an identical
+                // boot range here) means the file's boot sector differs from the PCM's. It has to be
+                // written and this PCM cannot do it, so the operation must not start.
                 if ((range.Type & BlockType.Boot) != 0)
                 {
                     return false;
@@ -109,6 +122,68 @@ namespace PcmHacking
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// What to tell the user when <see cref="BootPolicyAllowsWritePlan"/> refuses the operation.
+        /// Shared so the VPW and CAN writers word it identically.
+        /// </summary>
+        public static string[] DescribeBootSectorAbort(PcmType hardwareType, bool forceAllSectors)
+        {
+            string cause = forceAllSectors
+                ? $"Force write all sectors is selected, but the {hardwareType} cannot rewrite its boot sector."
+                : $"This write needs the boot sector rewritten, but the {hardwareType} cannot rewrite it.";
+
+            return new[]
+            {
+                cause,
+                "Abort: the boot sector in this file differs from the one in the PCM, so it cannot be written.",
+            };
+        }
+
+        /// <summary>
+        /// What to tell the user when a forced pass proceeds with boot left out. Shared for the same
+        /// reason as <see cref="DescribeBootSectorAbort"/>.
+        /// </summary>
+        public static string DescribeBootExclusion(PcmType hardwareType) =>
+            $"Force write all sectors: the boot sector already matches and the {hardwareType} cannot rewrite it, " +
+            "so boot is excluded from the write. Every other sector will be written.";
+
+        /// <summary>
+        /// True when a forced pass is dropping a boot range it would otherwise have rewritten, because
+        /// the PCM cannot rewrite boot and the boot sector is already identical. Purely so the writers
+        /// can tell the user that "force all sectors" did not include boot, and why.
+        /// </summary>
+        public static bool ForcedPlanExcludesBoot(
+            WriteType writeType,
+            bool supportsBootSectorWrite,
+            BlockType relevantBlocks,
+            UInt32 effectiveImageSize,
+            IEnumerable<MemoryRange> memoryRanges,
+            bool forceAllSectors)
+        {
+            if (!forceAllSectors || supportsBootSectorWrite)
+            {
+                return false;
+            }
+
+            foreach (MemoryRange range in memoryRanges)
+            {
+                bool isBoot = (range.Type & BlockType.Boot) != 0;
+                bool inScope = range.Address < effectiveImageSize && (range.Type & relevantBlocks) != 0;
+                if (!isBoot || !inScope)
+                {
+                    continue;
+                }
+
+                // In scope and forced, but ShouldProcessRange leaves it out: that is the exclusion.
+                if (!ShouldProcessRange(range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors, supportsBootSectorWrite))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Apps/PcmLibrary/Misc/WritePlan.cs
+++ b/Apps/PcmLibrary/Misc/WritePlan.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using System;
+using System.Collections.Generic;
+
+namespace PcmHacking
+{
+    /// <summary>
+    /// The single decision about what a write operation will actually touch, shared by the VPW
+    /// (<see cref="CKernelWriter"/>) and CAN (<see cref="CanKernelWriter"/>) writers.
+    /// </summary>
+    /// <remarks>
+    /// Both writers ask two questions: "will this range be erased/written?" and "does that plan
+    /// require a boot-sector write this PCM cannot do?". Those answers MUST come from the same
+    /// place. When they did not, a forced full write could pass the boot-sector gate (which
+    /// evaluated the plan by CRC) and then write boot anyway (because the write loop honoured the
+    /// force flag) - turning a recoverable PCM into a hard brick on a P05/P05b/P12/P05c.
+    /// </remarks>
+    public static class WritePlan
+    {
+        /// <summary>
+        /// Whether this range will be erased and written by the operation.
+        /// </summary>
+        /// <param name="forceAllSectors">
+        /// True for a forced full-write pass, which rewrites every in-scope sector even when its
+        /// on-device CRC already matches the image. Scope (image size and relevant block types) is
+        /// still honoured: forcing rewrites more sectors, it never widens what is in scope.
+        /// </param>
+        public static bool ShouldProcessRange(
+            MemoryRange range,
+            BlockType relevantBlocks,
+            WriteType writeType,
+            UInt32 effectiveImageSize,
+            bool forceAllSectors)
+        {
+            // Out of scope for this image. The P10 has the same flash chip as the P59, but the high
+            // bit of the address bus isn't connected, so talking to the top 512kb is a hardware
+            // error; for P10/P11 the usable size is the smaller PCM-type size.
+            if (range.Address >= effectiveImageSize)
+            {
+                return false;
+            }
+
+            // Not a block type this operation covers (e.g. boot is not in scope for a calibration
+            // write). Never processed, forced or not.
+            if ((range.Type & relevantBlocks) == 0)
+            {
+                return false;
+            }
+
+            // A forced pass includes every in-scope sector regardless of CRC.
+            if (forceAllSectors)
+            {
+                return true;
+            }
+
+            // Already identical on the device, so there is nothing to do (a test write always runs,
+            // because the point of it is to exercise the transfer).
+            if ((range.ActualCrc == range.DesiredCrc) && (writeType != WriteType.TestWrite))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Whether the PCM's boot-sector policy permits this write plan. False means the operation
+        /// must abort before anything is erased.
+        /// </summary>
+        /// <remarks>
+        /// A PCM that cannot write its boot sector may still be cloned, as long as the plan does not
+        /// actually write boot - i.e. the image's boot sector already matches the PCM's, or boot is
+        /// not in scope. Only a plan that would erase/write a boot range is refused. Pass the same
+        /// <paramref name="forceAllSectors"/> the write loop uses, or the gate and the loop can
+        /// disagree about whether boot is included.
+        /// </remarks>
+        public static bool BootPolicyAllowsWritePlan(
+            WriteType writeType,
+            bool supportsBootSectorWrite,
+            BlockType relevantBlocks,
+            UInt32 effectiveImageSize,
+            IEnumerable<MemoryRange> memoryRanges,
+            bool forceAllSectors)
+        {
+            // Compare and test-write are non-destructive.
+            if (writeType == WriteType.Compare || writeType == WriteType.TestWrite)
+            {
+                return true;
+            }
+
+            // Boot sector writes are supported; allow all write plans.
+            if (supportsBootSectorWrite)
+            {
+                return true;
+            }
+
+            foreach (MemoryRange range in memoryRanges)
+            {
+                if (!ShouldProcessRange(range, relevantBlocks, writeType, effectiveImageSize, forceAllSectors))
+                {
+                    continue;
+                }
+
+                // This plan would erase/write boot on a PCM that cannot rewrite it.
+                if ((range.Type & BlockType.Boot) != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Apps/PcmLibrary/Package/PackageStore.cs
+++ b/Apps/PcmLibrary/Package/PackageStore.cs
@@ -32,6 +32,62 @@ namespace PcmHacking
         public static IReadOnlyList<string> SupportedExtensions =>
             Formats.Select(f => f.Extension).ToList();
 
+        /// <summary>
+        /// The base file name (no extension) to suggest when saving a document: the name it already
+        /// has, or for a document that has never been saved, one built from what was read -
+        /// <c>[PCM]_[OSID]_[Date]</c>, e.g. "E38_12628990_20260821".
+        /// </summary>
+        /// <param name="package">The working document. May be null.</param>
+        /// <param name="currentPath">
+        /// Where the document currently lives, or null for a document that has never been saved (a
+        /// fresh read). Pass null to have the name built from the package.
+        /// </param>
+        /// <remarks>
+        /// Lives here so the naming rule exists once for every UI. A front end that substituted its own
+        /// display text produced files called "Untitled (unsaved read).phz"; the callers now ask for
+        /// this instead of inventing a name.
+        /// </remarks>
+        public static string DefaultBaseName(PcmPackage? package, string? currentPath)
+        {
+            if (!string.IsNullOrWhiteSpace(currentPath))
+            {
+                return Path.GetFileNameWithoutExtension(currentPath);
+            }
+
+            PackageController? controller = package?.Controllers?.FirstOrDefault();
+            string module = FirstNonBlank(controller?.ModuleType, controller?.Type) ?? "PCM";
+            uint? osid = controller?.Image("main")?.Osid;
+            string date = DateTime.Now.ToString("yyyyMMdd");
+
+            string name = osid != null
+                ? module + "_" + osid + "_" + date
+                : module + "_" + date;
+
+            return Sanitize(name);
+        }
+
+        private static string? FirstNonBlank(string? first, string? second) =>
+            !string.IsNullOrWhiteSpace(first) ? first
+            : !string.IsNullOrWhiteSpace(second) ? second
+            : null;
+
+        /// <summary>
+        /// Strip anything the host file system would reject. A module type comes from the package's
+        /// manifest, so it is not guaranteed to be a legal file name.
+        /// </summary>
+        private static string Sanitize(string name)
+        {
+            char[] invalid = Path.GetInvalidFileNameChars();
+            var clean = new System.Text.StringBuilder(name.Length);
+            foreach (char c in name)
+            {
+                clean.Append(Array.IndexOf(invalid, c) >= 0 ? '_' : c);
+            }
+
+            string result = clean.ToString().Trim();
+            return result.Length > 0 ? result : "PCM";
+        }
+
         /// <summary>Load a package from a file. Dispatches on the file's extension.</summary>
         public static PcmPackage Load(string path)
         {

--- a/Apps/PcmLibrary/Package/PackageStore.cs
+++ b/Apps/PcmLibrary/Package/PackageStore.cs
@@ -35,22 +35,35 @@ namespace PcmHacking
         /// <summary>
         /// The base file name (no extension) to suggest when saving a document: the name it already
         /// has, or for a document that has never been saved, one built from what was read -
-        /// <c>[PCM]_[OSID]_[Date]</c>, e.g. "E38_12628990_20260821".
+        /// <c>[PCM]_[OSID]_[Date]_[Seq]</c>, e.g. "E38_12628990_20260821_1".
         /// </summary>
         /// <param name="package">The working document. May be null.</param>
         /// <param name="currentPath">
         /// Where the document currently lives, or null for a document that has never been saved (a
         /// fresh read). Pass null to have the name built from the package.
         /// </param>
+        /// <param name="directory">
+        /// Where the save dialog will open, so the sequence number can skip names already on disk.
+        /// Pass null when the location is not known yet; the name is then simply sequence 1.
+        /// </param>
         /// <remarks>
         /// Lives here so the naming rule exists once for every UI. A front end that substituted its own
         /// display text produced files called "Untitled (unsaved read).phz"; the callers now ask for
         /// this instead of inventing a name.
+        /// <para>
+        /// The sequence number is always present, so several reads of the same PCM on the same day are
+        /// distinct files rather than one repeatedly overwritten. It is claimed against every supported
+        /// extension, not just the one being saved: a stem is skipped if either "name.phz" or
+        /// "name.bin" exists, so sequence N always refers to one read regardless of the format chosen.
+        /// This only picks the suggested name - the dialog still prompts before overwriting if the user
+        /// types over it.
+        /// </para>
         /// </remarks>
-        public static string DefaultBaseName(PcmPackage? package, string? currentPath)
+        public static string DefaultBaseName(PcmPackage? package, string? currentPath, string? directory)
         {
             if (!string.IsNullOrWhiteSpace(currentPath))
             {
+                // Already has a name of its own; saving again should keep it, not start a new sequence.
                 return Path.GetFileNameWithoutExtension(currentPath);
             }
 
@@ -63,7 +76,73 @@ namespace PcmHacking
                 ? module + "_" + osid + "_" + date
                 : module + "_" + date;
 
-            return Sanitize(name);
+            return NextFreeInSequence(Sanitize(name), directory);
+        }
+
+        /// <summary>
+        /// Append the lowest sequence number whose name is not already taken in
+        /// <paramref name="directory"/>. Numbering starts at 1 and the suffix is always added.
+        /// </summary>
+        private static string NextFreeInSequence(string stem, string? directory)
+        {
+            // Nothing to collide with (unknown or missing directory): sequence 1.
+            if (!DirectoryIsUsable(directory))
+            {
+                return stem + "_1";
+            }
+
+            // Bounded so a directory in a strange state can never spin here. A thousand reads of one
+            // PCM in one day into one folder is not a real case; falling back to a time-stamped
+            // suffix keeps the name unique rather than returning one that is known to be taken.
+            for (int sequence = 1; sequence <= 1000; sequence++)
+            {
+                string candidate = stem + "_" + sequence;
+                if (!AnySupportedFileExists(directory!, candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            return stem + "_" + DateTime.Now.ToString("HHmmss");
+        }
+
+        private static bool DirectoryIsUsable(string? directory)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                return false;
+            }
+
+            try
+            {
+                return Directory.Exists(directory);
+            }
+            catch (Exception)
+            {
+                // A malformed path is not worth failing a save over; treat it as "cannot check".
+                return false;
+            }
+        }
+
+        private static bool AnySupportedFileExists(string directory, string baseName)
+        {
+            foreach (IPackageFormat format in Formats)
+            {
+                try
+                {
+                    if (File.Exists(Path.Combine(directory, baseName + format.Extension)))
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Unreadable path: stop probing and let the caller use this name.
+                    return false;
+                }
+            }
+
+            return false;
         }
 
         private static string? FirstNonBlank(string? first, string? second) =>

--- a/Apps/PcmLibrary/ReadManager.cs
+++ b/Apps/PcmLibrary/ReadManager.cs
@@ -402,22 +402,19 @@ namespace PcmHacking
                 }
             }
 
-            // The forced-type path (normally the type detected at form load) skips the detection
-            // branch that routes CAN to its own path, so dispatch here too (mirrors WriteManager). Put
-            // the device on CAN and point it at the PCM first, else the VPW unlock/kernel flow runs
-            // over the CAN bus and no seed is parsed.
-            if (pcmInfo.BusProtocol == BusProtocol.Can500k)
+            // Select the bus once the PCM type is known, whichever branch above resolved it. Every
+            // route ends here, so a CAN PCM cannot reach the VPW flow below. WriteManager does the
+            // same with the same helper.
+            switch (await this.vehicle.PrepareBusFor(pcmInfo))
             {
-                this.vehicle.SetTarget(Target.Pcm);
-                if (!await this.vehicle.SelectBus(BusProtocol.Can500k))
-                {
+                case BusPreparation.Unavailable:
                     string msg = $"Abort: this device cannot use the CAN bus required by the {pcmInfo.HardwareType} PCM.";
                     logger.AddUserMessage(msg);
                     await this.invoke(async () => await this.alert(msg, "Abort"));
                     return null;
-                }
 
-                return await this.RunCanRead(progress, pcmInfo);
+                case BusPreparation.Ready:
+                    return await this.RunCanRead(progress, pcmInfo);
             }
 
             if (!pcmInfo.IsSupported)
@@ -451,7 +448,7 @@ namespace PcmHacking
 
             await this.vehicle.SuppressChatter();
 
-            bool unlocked = await this.vehicle.UnlockEcu(pcmInfo.KeyAlgorithm);
+            bool unlocked = await this.vehicle.UnlockEcu(pcmInfo.KeyAlgorithm, this.cancellationToken);
             if (!unlocked)
             {
                 logger.AddUserMessage("Unlock was not successful.");

--- a/Apps/PcmLibrary/ReadManager.cs
+++ b/Apps/PcmLibrary/ReadManager.cs
@@ -117,6 +117,26 @@ namespace PcmHacking
         public Task<PcmPackage?> ReadToPackage(PcmType forcedPcmType = PcmType.Undefined) =>
             this.ReadToPackage(null, forcedPcmType);
 
+        /// <summary>
+        /// Read a PCM that is in recovery mode into an in-memory package. The PCM type is supplied by
+        /// the user because a PCM in recovery reports no operating system; detection, the OSID query and
+        /// the kernel probe are all skipped. See <see cref="RecoveryMode"/>. Null on failure or abort.
+        /// </summary>
+        public async Task<PcmPackage?> RecoveryRead(PcmType pcmType, IProgress<ProgressUpdate>? progress = null)
+        {
+            if (!RecoveryMode.CanAttempt(pcmType, out string reason))
+            {
+                logger.AddUserMessage(reason);
+                await this.invoke(async () => await this.alert(reason, "PCM Recovery"));
+                return null;
+            }
+
+            logger.AddUserMessage(RecoveryMode.DescribeEntry(pcmType, isWrite: false));
+
+            // Forcing the type is what takes us straight into the recovery flow.
+            return await this.ReadToPackage(progress, pcmType);
+        }
+
         /// <summary>As <see cref="ReadToPackage(PcmType)"/>, reporting progress during the read.</summary>
         public async Task<PcmPackage?> ReadToPackage(IProgress<ProgressUpdate>? progress, PcmType forcedPcmType = PcmType.Undefined)
         {

--- a/Apps/PcmLibrary/Vehicle.Detection.cs
+++ b/Apps/PcmLibrary/Vehicle.Detection.cs
@@ -6,6 +6,21 @@ using System.Threading.Tasks;
 
 namespace PcmHacking
 {
+    /// <summary>
+    /// Outcome of <see cref="Vehicle.PrepareBusFor"/>.
+    /// </summary>
+    public enum BusPreparation
+    {
+        /// <summary>This PCM is not on CAN; the caller's VPW flow applies.</summary>
+        NotRequired,
+
+        /// <summary>The device is now on CAN and pointed at the PCM.</summary>
+        Ready,
+
+        /// <summary>The PCM needs CAN, but this device cannot do CAN.</summary>
+        Unavailable,
+    }
+
     public partial class Vehicle
     {
         // What a scan probes for, and the buses it tries. Add more targets/buses here as supported.
@@ -184,6 +199,30 @@ namespace PcmHacking
         /// Returns false if the device cannot do that bus.
         /// </summary>
         public Task<bool> SelectBus(BusProtocol bus) => this.device.SetProtocol(bus);
+
+        /// <summary>
+        /// Put the device on whichever bus this PCM's profile says it lives on, and point it at the
+        /// PCM. Call this once the PCM type is known, however it became known - detection, an OSID
+        /// query, a type the user forced, or a type inferred from the file.
+        /// </summary>
+        /// <remarks>
+        /// This exists so bus selection is decided in one place from <see cref="OSIDInfo.BusProtocol"/>
+        /// rather than at each point a PCM type happens to be resolved. Missing it means the VPW
+        /// unlock/kernel flow runs against a CAN PCM: nothing answers, no seed is ever parsed, and the
+        /// operation grinds through its full retry budget before failing.
+        /// </remarks>
+        public async Task<BusPreparation> PrepareBusFor(OSIDInfo pcmInfo)
+        {
+            if (pcmInfo.BusProtocol != BusProtocol.Can500k)
+            {
+                return BusPreparation.NotRequired;
+            }
+
+            this.SetTarget(Target.Pcm);
+            return await this.SelectBus(BusProtocol.Can500k)
+                ? BusPreparation.Ready
+                : BusPreparation.Unavailable;
+        }
 
         /// <summary>
         /// Quick OSID probe on the current bus: VPW uses the block-read OSID request, CAN uses GMLAN

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -470,11 +470,15 @@ namespace PcmHacking
             return $"{dt:yyyy-MM-dd HH:mm:ss} PCM=0x{pcmType:X2}";
         }
 
-        public async Task<UInt64> GetKernelVersion(int maxRetries = 5)
-        {
-            return await this.GetKernelVersion(CancellationToken.None, maxRetries);
-        }
-
+        /// <summary>
+        /// Ask a running kernel for its version. Returns 0 if no kernel answers.
+        /// </summary>
+        /// <remarks>
+        /// The token is deliberately required rather than optional. There used to be a convenience
+        /// overload without one that forwarded CancellationToken.None; it read identically at the call
+        /// site, so WriteManager picked it up by accident and that step of a write could not be
+        /// cancelled at all. Making the token impossible to omit is what stops that recurring.
+        /// </remarks>
         public async Task<UInt64> GetKernelVersion(CancellationToken cancellationToken, int maxRetries = 5)
         {
             Message query = this.protocol.CreateKernelVersionQuery();

--- a/Apps/PcmLibrary/Vehicle.TestKernel.cs
+++ b/Apps/PcmLibrary/Vehicle.TestKernel.cs
@@ -73,7 +73,7 @@ namespace PcmHacking
                     Response<uint> osidResponse = await this.QueryOperatingSystemId(cancellationToken);
                     if (osidResponse.Status != ResponseStatus.Success)
                     {
-                        kernelVersion = await this.GetKernelVersion();
+                        kernelVersion = await this.GetKernelVersion(cancellationToken);
 
                         // TODO: Check for recovery mode.                    
                         // TODO: Load the tiny kernel, then use that to load the test kernel.
@@ -87,7 +87,7 @@ namespace PcmHacking
                     }
 
                     logger.AddUserMessage("Unlocking PCM...");
-                    bool unlocked = await this.UnlockEcu(keyAlgorithm);
+                    bool unlocked = await this.UnlockEcu(keyAlgorithm, cancellationToken);
                     if (!unlocked)
                     {
                         logger.AddUserMessage("Unlock was not successful.");

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -1,6 +1,7 @@
 ﻿// SPDX-License-Identifier: GPL-3.0-only
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -41,6 +42,12 @@ namespace PcmHacking
         /// small margin.
         /// </summary>
         private static readonly TimeSpan SecurityDelayLockout = TimeSpan.FromSeconds(11);
+
+        /// <summary>
+        /// Wall-clock ceiling on a single unlock, covering all of its nested retries. Sized for three
+        /// seed/key rounds including one <see cref="SecurityDelayLockout"/> wait, plus slack.
+        /// </summary>
+        private static readonly TimeSpan UnlockTimeBudget = TimeSpan.FromSeconds(32);
 
         public CancellationTokenSource ShutdownSignalSource = new CancellationTokenSource(); // Use this as a trigger to say we are ready to dispose the underlying device.
 
@@ -300,9 +307,38 @@ namespace PcmHacking
         /// <summary>
         /// Unlock the PCM by requesting a 'seed' and then sending the corresponding 'key' value.
         /// </summary>
-        public async Task<bool> UnlockEcu(int keyAlgorithm)
+        /// <remarks>
+        /// <para>
+        /// The token is honoured at the top of every retry loop and during the security time-delay
+        /// wait, and is required rather than optional so it cannot be omitted by accident.
+        /// </para>
+        /// <para>
+        /// Retries are bounded by <see cref="UnlockTimeBudget"/> (wall clock) rather than by the
+        /// nested attempt counts alone. The per-receive timeout is computed per device and protocol
+        /// (a few hundred ms to several seconds), so the counts alone gave wildly different real
+        /// durations - on a slow J2534 link the full budget of three unlock attempts x three seed
+        /// requests x five receive timeouts ran for minutes. One deadline covers every loop and
+        /// keeps the retry structure simple.
+        /// </para>
+        /// </remarks>
+        public async Task<bool> UnlockEcu(int keyAlgorithm, CancellationToken cancellationToken)
         {
             await this.device.SetTimeout(TimeoutScenario.ReadProperty);
+
+            // Enough for three seed/key rounds including one security time-delay lockout
+            // (SecurityDelayLockout is 11s), plus slack for the message exchanges around them.
+            Stopwatch unlockClock = Stopwatch.StartNew();
+            bool BudgetSpent()
+            {
+                if (unlockClock.Elapsed < UnlockTimeBudget)
+                {
+                    return false;
+                }
+
+                logger.AddUserMessage(
+                    $"Giving up on unlock after {unlockClock.Elapsed.TotalSeconds:F0} seconds; the PCM is not responding as expected.");
+                return true;
+            }
 
             Message seedRequest = this.protocol.CreateSeedRequest();
 
@@ -327,6 +363,17 @@ namespace PcmHacking
 
             for (int unlockAttempt = 1; unlockAttempt <= MaxUnlockAttempts; unlockAttempt++)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    logger.AddUserMessage("Unlock cancelled.");
+                    return false;
+                }
+
+                if (BudgetSpent())
+                {
+                    return false;
+                }
+
                 this.device.ClearMessageQueue();
 
                 logger.AddDebugMessage("Sending seed request.");
@@ -344,6 +391,17 @@ namespace PcmHacking
                 const int MaxSeedRequests = 3;
                 for (int sendAttempt = 1; (sendAttempt <= MaxSeedRequests) && !seedReceived; sendAttempt++)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        logger.AddUserMessage("Unlock cancelled.");
+                        return false;
+                    }
+
+                    if (BudgetSpent())
+                    {
+                        return false;
+                    }
+
                     if (!await this.TrySendMessage(seedRequest, "seed request"))
                     {
                         logger.AddUserMessage("Unable to send seed request.");
@@ -357,6 +415,17 @@ namespace PcmHacking
                     // MaxReceiveAttempts timeouts before resending the request.
                     for (int receiveAttempt = 1; receiveAttempt <= 50; receiveAttempt++)
                     {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            logger.AddUserMessage("Unlock cancelled.");
+                            return false;
+                        }
+
+                        if (BudgetSpent())
+                        {
+                            return false;
+                        }
+
                         Message seedResponse = await this.device.ReceiveMessage();
                         if (seedResponse == null)
                         {
@@ -427,7 +496,15 @@ namespace PcmHacking
                         lockoutRetried = true;
                         sendAttempt--;
                         logger.AddUserMessage("PCM is in a security time-delay lockout. Waiting to retry.");
-                        await Task.Delay(SecurityDelayLockout);
+                        try
+                        {
+                            await Task.Delay(SecurityDelayLockout, cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            logger.AddUserMessage("Unlock cancelled.");
+                            return false;
+                        }
                     }
 
                     // No usable seed this round; clear anything stale and let the loop resend.
@@ -477,6 +554,17 @@ namespace PcmHacking
                 bool retryAfterDelay = false;
                 for (int attempt = 1; attempt < MaxReceiveAttempts; attempt++)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        logger.AddUserMessage("Unlock cancelled.");
+                        return false;
+                    }
+
+                    if (BudgetSpent())
+                    {
+                        return false;
+                    }
+
                     Message unlockResponse = await this.device.ReceiveMessage();
                     if (unlockResponse == null)
                     {
@@ -525,7 +613,15 @@ namespace PcmHacking
                 }
 
                 logger.AddUserMessage("PCM is enforcing a security time delay. Waiting to retry.");
-                await Task.Delay(SecurityDelayLockout);
+                try
+                {
+                    await Task.Delay(SecurityDelayLockout, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    logger.AddUserMessage("Unlock cancelled.");
+                    return false;
+                }
             }
 
             logger.AddUserMessage("Unable to process unlock response.");

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -298,33 +298,6 @@ namespace PcmHacking
 
 
         /// <summary>
-        /// Note that this has only been confirmed to work with ObdLink ScanTool devices.
-        /// AllPro doesn't get the reply for some reason.
-        /// Might work with AVT or J-tool, that hasn't been tested.
-        /// </summary>
-        public async Task<bool> IsInRecoveryMode()
-        {
-            this.device.ClearMessageQueue();
-
-            for (int iterations = 0; iterations < 10; iterations++)
-            {
-                await this.TrySendMessage(new Message(new byte[] { Priority.Physical0, DeviceId.Pcm, DeviceId.Tool, 0x62 }), "recovery query", 2);
-                Message response = await this.device.ReceiveMessage();
-                if (response == null)
-                {
-                    continue;
-                }
-
-                if (this.protocol.ParseRecoveryModeBroadcast(response).Value == true)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Unlock the PCM by requesting a 'seed' and then sending the corresponding 'key' value.
         /// </summary>
         public async Task<bool> UnlockEcu(int keyAlgorithm)

--- a/Apps/PcmLibrary/WriteManager.cs
+++ b/Apps/PcmLibrary/WriteManager.cs
@@ -40,7 +40,7 @@ namespace PcmHacking
         /// Load a file (a raw .bin or a .phz package) and write it. Accepts a string path for OSes that
         /// can directly access the file system.
         /// </summary>
-        public async Task<bool> Write(string path, PcmType forcedPcmType = PcmType.Undefined, bool suppressOSIDWarning = false)
+        public async Task<bool> Write(string path, PcmType forcedPcmType = PcmType.Undefined)
         {
             PcmPackage package;
             try
@@ -55,7 +55,7 @@ namespace PcmHacking
                 return false;
             }
 
-            return await this.Write(package, forcedPcmType, suppressOSIDWarning);
+            return await this.Write(package, forcedPcmType);
         }
 
         /// <summary>
@@ -64,7 +64,33 @@ namespace PcmHacking
         /// write, a full write programs the whole PCM through the boot loader; otherwise the master image
         /// is written the normal way and any slave in the PCM is left in place.
         /// </summary>
-        public async Task<bool> Write(PcmPackage package, PcmType forcedPcmType = PcmType.Undefined, bool suppressOSIDWarning = false)
+        /// <summary>
+        /// Write to a PCM that is in recovery mode. The PCM type is supplied by the user because a PCM
+        /// in recovery reports no operating system; detection, the OSID query and the kernel probe are
+        /// all skipped. See <see cref="RecoveryMode"/>.
+        /// </summary>
+        /// <remarks>
+        /// The boot-sector protection still applies in full: once the kernel is running it CRCs the
+        /// real flash, and <see cref="WritePlan.BootPolicyAllowsWritePlan"/> aborts before any erase if
+        /// the plan would write a boot sector this PCM cannot rewrite. That is what stops a recoverable
+        /// soft brick from becoming a hard brick.
+        /// </remarks>
+        public async Task<bool> RecoveryWrite(PcmPackage package, PcmType pcmType)
+        {
+            if (!RecoveryMode.CanAttempt(pcmType, out string reason))
+            {
+                logger.AddUserMessage(reason);
+                await this.alert(reason, "PCM Recovery");
+                return false;
+            }
+
+            logger.AddUserMessage(RecoveryMode.DescribeEntry(pcmType, isWrite: true));
+
+            // Forcing the type is what takes us straight into the recovery flow.
+            return await this.Write(package, pcmType);
+        }
+
+        public async Task<bool> Write(PcmPackage package, PcmType forcedPcmType = PcmType.Undefined)
         {
             PackageImage? main = SelectMainImage(package);
             if (main?.Data == null)
@@ -131,7 +157,7 @@ namespace PcmHacking
                     "This file has slave modules, but this PCM has no boot loader write path. Writing the master only.");
             }
 
-            return await Write(main.Data, forcedPcmType, suppressOSIDWarning);
+            return await Write(main.Data, forcedPcmType);
         }
 
         private static bool IsSlaveTarget(string? target) =>
@@ -326,13 +352,12 @@ namespace PcmHacking
         /// <summary>
         /// Contains cross-platform code to handle user interactions to write the PCM's flash memory.
         /// Accepts a byte array directly for OSes that don't support direct file handling.
-        /// suppressOSIDWarning: If true, the user will not be prompted to confirm that the OSID is correct (useful for recovery mode).
         /// </summary>
         /// <remarks>
         /// The return value should be used to suppress future warnings about using an unproven connection.
         /// </remarks>
         /// <returns>True if the write was successful, fales if failed or aborted.</returns>
-        public async Task<bool> Write(byte[] image, PcmType forcedPcmType = PcmType.Undefined, bool suppressOSIDWarning = false)
+        public async Task<bool> Write(byte[] image, PcmType forcedPcmType = PcmType.Undefined)
         {
             // Sanity checks.
             PcmType? forcedFileType = forcedPcmType != PcmType.Undefined ? forcedPcmType : (PcmType?)null;
@@ -421,19 +446,9 @@ namespace PcmHacking
                     await this.alert(msg, "Abort");
                     return false;
                 }
-                else if (!suppressOSIDWarning)
+                else if (this.cancellationToken.IsCancellationRequested)
                 {
-                    // The PCM did not return an OSID, so we cannot verify the file matches the
-                    // connected hardware. This is the genuine recovery case (corrupt or truly
-                    // unidentified PCM), so we don't hard-block, but we must NOT proceed silently:
-                    // warn that compatibility is unverified and let the user accept the brick risk.
-                    if (this.cancellationToken.IsCancellationRequested)
-                    {
-                        string msg = $"Abort: this file is for a {fileType} PCM, but {forcedPcmType} was selected.";
-                        logger.AddUserMessage(msg);
-                        await this.alert(msg, "Abort");
-                        return false;
-                    }
+                    return false;
                 }
                 if (fileType != forcedPcmType && RuntimeSettings.AllowCrossFlashing)
                 {
@@ -504,20 +519,21 @@ namespace PcmHacking
                     kernelVersion = await this.vehicle.GetKernelVersion();
                     if (kernelVersion == 0)
                     {
-                        logger.AddUserMessage("Checking for recovery mode...");
-                        bool recoveryMode = await this.vehicle.IsInRecoveryMode();
-
-                        if (recoveryMode)
-                        {
-                            logger.AddUserMessage("PCM is in recovery mode.");
-                            needUnlock = true;
-                        }
-                        else
-                        {
-                            logger.AddUserMessage("PCM is not responding to OSID, kernel version, or recovery mode checks.");
-                            logger.AddUserMessage("Unlock may not work, but we'll try...");
-                            needUnlock = true;
-                        }
+                        // The PCM answered neither the OSID query nor the kernel version query, so it is
+                        // almost certainly sitting in its boot loader (recovery). We cannot learn the type
+                        // from the PCM, so the file's OSID supplies it and we try the unlock.
+                        //
+                        // There is deliberately no recovery probe here. A PCM in recovery announces itself
+                        // by broadcasting unsolicited (0xA2, "programming prompt") - see
+                        // Vehicle.CheckForRecoveryMode, which listens for exactly that. The old active
+                        // "recovery query" sent mode 0x62 and parsed the reply, which is a programming-mode
+                        // style request rather than recovery detection; it only ever worked on ObdLink
+                        // ScanTool hardware and both of its outcomes did the same thing, so it decided
+                        // nothing and has been removed. Use Tools -> PCM Recovery for an explicit recovery
+                        // operation, where the user names the PCM type.
+                        logger.AddUserMessage("PCM is not responding to OSID or kernel version checks; assuming recovery mode.");
+                        logger.AddUserMessage("Unlock may not work, but we'll try...");
+                        needUnlock = true;
                         pcmInfo = new OSIDInfo(validator.GetOsidFromImage()); // Prevent Null Reference Exceptions from breaking Recovery Mode
                     }
                     else

--- a/Apps/PcmLibrary/WriteManager.cs
+++ b/Apps/PcmLibrary/WriteManager.cs
@@ -209,15 +209,8 @@ namespace PcmHacking
             logger.AddUserMessage("File OSID: " + validator.GetOsidFromImage());
             logger.AddUserMessage("File Description: " + new OSIDInfo(validator.GetFileType()).Description + ".");
 
-            string warning =
-                "This will program the FULL PCM - the master flash AND the slave CPU - through the boot " +
-                "loader. It is EXPERIMENTAL and can brick the PCM. Continue?";
-            logger.AddUserMessage(warning);
-            if (!await this.promptForYesNo(warning, "Brick Risk"))
-            {
-                logger.AddUserMessage("User chose not to proceed.");
-                return false;
-            }
+            logger.AddUserMessage(
+                "Programming the FULL PCM - the master flash AND the slave CPU - through the boot loader.");
 
             List<byte[]> masterModules;
             try
@@ -359,6 +352,19 @@ namespace PcmHacking
         /// <returns>True if the write was successful, fales if failed or aborted.</returns>
         public async Task<bool> Write(byte[] image, PcmType forcedPcmType = PcmType.Undefined)
         {
+            // WriteType.None is not an operation; it means a caller never chose one (it is the CLR
+            // default of the enum, so an unset UI binding produces it). Reject it here, before any
+            // bus work: the writers only discover it at their block-selection switch, by which point
+            // the kernel has already been uploaded and is running on the PCM, and the user sees an
+            // "Unsuppported operation type" exception instead of a plain message.
+            if (this.writeType == WriteType.None)
+            {
+                string msg = "Abort: no write type was selected.";
+                logger.AddUserMessage(msg);
+                await this.alert(msg, "Abort");
+                return false;
+            }
+
             // Sanity checks.
             PcmType? forcedFileType = forcedPcmType != PcmType.Undefined ? forcedPcmType : (PcmType?)null;
             FileValidator validator = new FileValidator(image, this.logger, forcedFileType);
@@ -458,21 +464,8 @@ namespace PcmHacking
                 }
 
                 // A forced CAN PCM (e.g. E38) is written by the CAN path, not the VPW flow below.
-                // Put the device on CAN, point it at the PCM, and hand off - mirroring the auto-detected
-                // CAN route above (RunCanWrite assumes the device is already selected on CAN).
-                if (pcmInfo.BusProtocol == BusProtocol.Can500k)
-                {
-                    this.vehicle.SetTarget(Target.Pcm);
-                    if (!await this.vehicle.SelectBus(BusProtocol.Can500k))
-                    {
-                        string msg = $"Abort: this device cannot use the CAN bus required by the {pcmInfo.HardwareType} PCM.";
-                        logger.AddUserMessage(msg);
-                        await this.alert(msg, "Abort");
-                        return false;
-                    }
-
-                    return await this.RunCanWrite(image, validator);
-                }
+                // The dispatch is not here: it is below, after every branch has resolved pcmInfo, so
+                // one place covers the forced type, a queried OSID, and a type inferred from the file.
             }
             else
             {
@@ -516,7 +509,7 @@ namespace PcmHacking
 
                     logger.AddUserMessage("Operating system request failed, checking for a live kernel...");
 
-                    kernelVersion = await this.vehicle.GetKernelVersion();
+                    kernelVersion = await this.vehicle.GetKernelVersion(this.cancellationToken);
                     if (kernelVersion == 0)
                     {
                         // The PCM answered neither the OSID query nor the kernel version query, so it is
@@ -566,6 +559,24 @@ namespace PcmHacking
                         needToCheckOperatingSystem = false;
                     }
                 }
+            }
+
+            // Select the bus once the PCM type is known, whichever branch above resolved it - the
+            // forced type, an OSID queried from the PCM, or (when the PCM answers nothing and we
+            // assume recovery) the type inferred from the file. That last route is why this sits
+            // here rather than inside a branch: an E38 file against a silent bus resolved to a CAN
+            // profile and then ran the whole VPW unlock/kernel flow anyway. ReadManager does the
+            // same with the same helper.
+            switch (await this.vehicle.PrepareBusFor(pcmInfo!))
+            {
+                case BusPreparation.Unavailable:
+                    string busMsg = $"Abort: this device cannot use the CAN bus required by the {pcmInfo!.HardwareType} PCM.";
+                    logger.AddUserMessage(busMsg);
+                    await this.alert(busMsg, "Abort");
+                    return false;
+
+                case BusPreparation.Ready:
+                    return await this.RunCanWrite(image, validator);
             }
 
             // Pre flight checks to block invalid write operations by PCM type.
@@ -653,7 +664,7 @@ namespace PcmHacking
             if (needUnlock)
             {
 
-                bool unlocked = await this.vehicle.UnlockEcu(keyAlgorithm);
+                bool unlocked = await this.vehicle.UnlockEcu(keyAlgorithm, this.cancellationToken);
                 if (!unlocked)
                 {
                     logger.AddUserMessage("Unlock was not successful.");

--- a/Apps/PcmLibraryWindowsApi/PcmLibraryWindowsApi.csproj
+++ b/Apps/PcmLibraryWindowsApi/PcmLibraryWindowsApi.csproj
@@ -13,8 +13,14 @@
     <!-- Some PackageReferences (e.g. System.Management) carry runtime-specific assets; VS
          msbuild's NuGet asset resolver requires a RuntimeIdentifier to pick them, otherwise
          it errors. net48 only ever runs on Windows, so pin 'win'. (dotnet build does not
-         require this, but the release build uses msbuild so Costura embeds the full closure.) -->
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
+         require this, but the release build uses msbuild so Costura embeds the full closure.)
+
+         Scoped to net48 deliberately. Applied to every framework it also became the RID for
+         the net10.0-windows leg, and 'win' is an abstract RID with no runtime pack, so any
+         RID-specific publish of a net10.0 consumer (the WPF app's single-file build) died
+         with NETSDK1082. NuGet unions RIDs across frameworks when it writes
+         project.assets.json, so net48/win is still restored exactly as before. -->
+    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'net48'">win</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/Apps/Tests/CanKernelBootPolicyTests.cs
+++ b/Apps/Tests/CanKernelBootPolicyTests.cs
@@ -110,7 +110,9 @@ namespace Tests
         public void ShouldProcessRange_SkipsMatchingCrc_OnRealWrite()
         {
             var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 7, DesiredCrc = 7 };
-            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(range, BlockType.All, WriteType.Full, ImageSize));
+            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: false, supportsBootSectorWrite: true));
         }
 
         [TestMethod]
@@ -118,21 +120,27 @@ namespace Tests
         {
             // A test write exercises every relevant range regardless of CRC.
             var range = new MemoryRange(0x08000, 0x08000, BlockType.Calibration) { ActualCrc = 7, DesiredCrc = 7 };
-            Assert.IsTrue(CanKernelWriter.ShouldProcessRange(range, BlockType.Calibration, WriteType.TestWrite, ImageSize));
+            Assert.IsTrue(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.Calibration, WriteType.TestWrite, ImageSize,
+                forceAllSectors: false, supportsBootSectorWrite: true));
         }
 
         [TestMethod]
         public void ShouldProcessRange_SkipsRangeOutsideImage()
         {
             var range = new MemoryRange(ImageSize, 0x04000, BlockType.OperatingSystem) { ActualCrc = 1, DesiredCrc = 2 };
-            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(range, BlockType.All, WriteType.Full, ImageSize));
+            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: false, supportsBootSectorWrite: true));
         }
 
         [TestMethod]
         public void ShouldProcessRange_SkipsIrrelevantBlockType()
         {
             var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 1, DesiredCrc = 2 };
-            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(range, BlockType.Calibration, WriteType.Full, ImageSize));
+            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.Calibration, WriteType.Full, ImageSize,
+                forceAllSectors: false, supportsBootSectorWrite: true));
         }
 
         // ---- Forced full write (RuntimeSettings.ForceWriteAllSectors) ----
@@ -141,17 +149,45 @@ namespace Tests
         // hard brick on hardware whose boot sector cannot be rewritten.
 
         [TestMethod]
-        public void NoBootSupport_ForcedFullWrite_BootMatches_IsBlocked()
+        public void NoBootSupport_ForcedFullWrite_BootMatches_IsAllowed()
         {
-            // Boot CRC matches, so an ordinary write would skip boot - but a forced pass rewrites every
-            // in-scope sector, boot included. The gate must refuse it.
+            // Boot already matches, so there is nothing to gain by erasing and rewriting it - and on a
+            // PCM that cannot rewrite boot that erase is the brick. Boot drops out of the plan and the
+            // forced write proceeds with every other sector.
             var ranges = Layout(bootActualCrc: 0xAAAA, bootDesiredCrc: 0xAAAA, calActualCrc: 0x1111, calDesiredCrc: 0x2222);
 
             bool allowed = CanKernelWriter.BootPolicyAllowsWritePlan(
                 WriteType.Full, supportsBootSectorWrite: false, BlockType.All, ImageSize, ranges,
                 forceAllSectors: true);
 
+            Assert.IsTrue(allowed);
+            Assert.IsTrue(WritePlan.ForcedPlanExcludesBoot(
+                WriteType.Full, supportsBootSectorWrite: false, BlockType.All, ImageSize, ranges,
+                forceAllSectors: true));
+        }
+
+        [TestMethod]
+        public void NoBootSupport_ForcedFullWrite_BootDiffers_IsBlocked()
+        {
+            // Boot genuinely needs writing and this PCM cannot do it. Refuse before anything is erased.
+            var ranges = Layout(bootActualCrc: 0xAAAA, bootDesiredCrc: 0xBBBB, calActualCrc: 0x1111, calDesiredCrc: 0x2222);
+
+            bool allowed = CanKernelWriter.BootPolicyAllowsWritePlan(
+                WriteType.Full, supportsBootSectorWrite: false, BlockType.All, ImageSize, ranges,
+                forceAllSectors: true);
+
             Assert.IsFalse(allowed);
+        }
+
+        [TestMethod]
+        public void ForcedAbortMessage_NamesForceAsTheCause()
+        {
+            string[] forced = WritePlan.DescribeBootSectorAbort(PcmType.P05b, forceAllSectors: true);
+            StringAssert.Contains(forced[0], "Force write all sectors");
+            StringAssert.Contains(forced[1], "Abort:");
+
+            string[] plain = WritePlan.DescribeBootSectorAbort(PcmType.P05b, forceAllSectors: false);
+            Assert.IsFalse(plain[0].Contains("Force write all sectors"));
         }
 
         [TestMethod]
@@ -183,9 +219,42 @@ namespace Tests
         [TestMethod]
         public void ShouldProcessRange_Forced_ProcessesMatchingCrc()
         {
+            // A PCM that CAN rewrite boot honours the force flag everywhere, boot included.
             var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 7, DesiredCrc = 7 };
             Assert.IsTrue(CanKernelWriter.ShouldProcessRange(
-                range, BlockType.All, WriteType.Full, ImageSize, forceAllSectors: true));
+                range, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: true, supportsBootSectorWrite: true));
+        }
+
+        [TestMethod]
+        public void ShouldProcessRange_Forced_SkipsMatchingBoot_WhenBootIsUnwritable()
+        {
+            // Same forced write on a PCM that cannot rewrite boot: the identical boot range is left
+            // out rather than erased and rewritten as a no-op.
+            var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 7, DesiredCrc = 7 };
+            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: true, supportsBootSectorWrite: false));
+        }
+
+        [TestMethod]
+        public void ShouldProcessRange_Forced_KeepsDifferingBoot_WhenBootIsUnwritable()
+        {
+            // Differing boot stays in the plan so the boot-policy gate can refuse the whole operation.
+            var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 7, DesiredCrc = 8 };
+            Assert.IsTrue(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: true, supportsBootSectorWrite: false));
+        }
+
+        [TestMethod]
+        public void ShouldProcessRange_Forced_NonBootIsStillForced_WhenBootIsUnwritable()
+        {
+            // The boot carve-out must not weaken forcing anywhere else.
+            var cal = new MemoryRange(0x08000, 0x08000, BlockType.Calibration) { ActualCrc = 7, DesiredCrc = 7 };
+            Assert.IsTrue(CanKernelWriter.ShouldProcessRange(
+                cal, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: true, supportsBootSectorWrite: false));
         }
 
         [TestMethod]
@@ -194,11 +263,13 @@ namespace Tests
             // Force must not widen scope: out-of-image and irrelevant-block ranges stay skipped.
             var outside = new MemoryRange(ImageSize, 0x04000, BlockType.OperatingSystem) { ActualCrc = 1, DesiredCrc = 2 };
             Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
-                outside, BlockType.All, WriteType.Full, ImageSize, forceAllSectors: true));
+                outside, BlockType.All, WriteType.Full, ImageSize,
+                forceAllSectors: true, supportsBootSectorWrite: true));
 
             var irrelevant = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 1, DesiredCrc = 2 };
             Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
-                irrelevant, BlockType.Calibration, WriteType.Full, ImageSize, forceAllSectors: true));
+                irrelevant, BlockType.Calibration, WriteType.Full, ImageSize,
+                forceAllSectors: true, supportsBootSectorWrite: true));
         }
     }
 }

--- a/Apps/Tests/CanKernelBootPolicyTests.cs
+++ b/Apps/Tests/CanKernelBootPolicyTests.cs
@@ -134,5 +134,71 @@ namespace Tests
             var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 1, DesiredCrc = 2 };
             Assert.IsFalse(CanKernelWriter.ShouldProcessRange(range, BlockType.Calibration, WriteType.Full, ImageSize));
         }
+
+        // ---- Forced full write (RuntimeSettings.ForceWriteAllSectors) ----
+        // The gate must be evaluated with the same force flag the write loop uses. Otherwise a forced
+        // write passes the gate by CRC and then erases boot anyway, turning a recoverable PCM into a
+        // hard brick on hardware whose boot sector cannot be rewritten.
+
+        [TestMethod]
+        public void NoBootSupport_ForcedFullWrite_BootMatches_IsBlocked()
+        {
+            // Boot CRC matches, so an ordinary write would skip boot - but a forced pass rewrites every
+            // in-scope sector, boot included. The gate must refuse it.
+            var ranges = Layout(bootActualCrc: 0xAAAA, bootDesiredCrc: 0xAAAA, calActualCrc: 0x1111, calDesiredCrc: 0x2222);
+
+            bool allowed = CanKernelWriter.BootPolicyAllowsWritePlan(
+                WriteType.Full, supportsBootSectorWrite: false, BlockType.All, ImageSize, ranges,
+                forceAllSectors: true);
+
+            Assert.IsFalse(allowed);
+        }
+
+        [TestMethod]
+        public void NoBootSupport_ForcedCalibrationWrite_IsAllowed()
+        {
+            // Forcing rewrites more sectors, but it never widens scope: boot is not in relevantBlocks
+            // for a calibration write, so the clone is still allowed on a no-boot-write PCM.
+            var ranges = Layout(bootActualCrc: 0xAAAA, bootDesiredCrc: 0xBBBB, calActualCrc: 0x1111, calDesiredCrc: 0x2222);
+
+            bool allowed = CanKernelWriter.BootPolicyAllowsWritePlan(
+                WriteType.Calibration, supportsBootSectorWrite: false, BlockType.Calibration, ImageSize, ranges,
+                forceAllSectors: true);
+
+            Assert.IsTrue(allowed);
+        }
+
+        [TestMethod]
+        public void BootSupport_ForcedFullWrite_IsAllowed()
+        {
+            var ranges = Layout(bootActualCrc: 0xAAAA, bootDesiredCrc: 0xAAAA, calActualCrc: 1, calDesiredCrc: 1);
+
+            bool allowed = CanKernelWriter.BootPolicyAllowsWritePlan(
+                WriteType.Full, supportsBootSectorWrite: true, BlockType.All, ImageSize, ranges,
+                forceAllSectors: true);
+
+            Assert.IsTrue(allowed);
+        }
+
+        [TestMethod]
+        public void ShouldProcessRange_Forced_ProcessesMatchingCrc()
+        {
+            var range = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 7, DesiredCrc = 7 };
+            Assert.IsTrue(CanKernelWriter.ShouldProcessRange(
+                range, BlockType.All, WriteType.Full, ImageSize, forceAllSectors: true));
+        }
+
+        [TestMethod]
+        public void ShouldProcessRange_Forced_StillSkipsOutOfScopeRanges()
+        {
+            // Force must not widen scope: out-of-image and irrelevant-block ranges stay skipped.
+            var outside = new MemoryRange(ImageSize, 0x04000, BlockType.OperatingSystem) { ActualCrc = 1, DesiredCrc = 2 };
+            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
+                outside, BlockType.All, WriteType.Full, ImageSize, forceAllSectors: true));
+
+            var irrelevant = new MemoryRange(0x00000, 0x04000, BlockType.Boot) { ActualCrc = 1, DesiredCrc = 2 };
+            Assert.IsFalse(CanKernelWriter.ShouldProcessRange(
+                irrelevant, BlockType.Calibration, WriteType.Full, ImageSize, forceAllSectors: true));
+        }
     }
 }

--- a/Apps/Tests/PackageNamingTests.cs
+++ b/Apps/Tests/PackageNamingTests.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 using System;
+using System.IO;
 
 using PcmHacking;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -14,6 +15,28 @@ namespace Tests
     [TestClass]
     public class PackageNamingTests
     {
+        private string dir = null!;
+
+        [TestInitialize]
+        public void CreateTempDirectory()
+        {
+            this.dir = Path.Combine(Path.GetTempPath(), "PcmHammerNaming_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.dir);
+        }
+
+        [TestCleanup]
+        public void RemoveTempDirectory()
+        {
+            try
+            {
+                if (Directory.Exists(this.dir)) Directory.Delete(this.dir, true);
+            }
+            catch (IOException)
+            {
+                // A leftover temp directory is not worth failing a test run over.
+            }
+        }
+
         private static string Today => DateTime.Now.ToString("yyyyMMdd");
 
         private static PcmPackage PackageWith(string? moduleType, string? type, uint? osid)
@@ -23,52 +46,51 @@ namespace Tests
             return new PcmPackage { Controllers = { controller } };
         }
 
+        private static PcmPackage E38 => PackageWith("E38", "PCM", 12628990);
+
+        private void Touch(string fileName) => File.WriteAllBytes(Path.Combine(this.dir, fileName), new byte[] { 0 });
+
+        // ---- Name shape ----
+
         [TestMethod]
-        public void UnsavedRead_UsesModuleOsidAndDate()
+        public void UnsavedRead_UsesModuleOsidDateAndSequence()
         {
-            Assert.AreEqual(
-                "E38_12628990_" + Today,
-                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", 12628990), null));
+            Assert.AreEqual("E38_12628990_" + Today + "_1", PackageStore.DefaultBaseName(E38, null, this.dir));
         }
 
         [TestMethod]
         public void AlreadySaved_KeepsExistingNameWithoutExtension()
         {
-            Assert.AreEqual(
-                "my read",
-                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", 12628990), @"C:\bins\my read.phz"));
+            // An existing document keeps its own name; it must not start a new sequence.
+            Assert.AreEqual("my read", PackageStore.DefaultBaseName(E38, Path.Combine(this.dir, "my read.phz"), this.dir));
         }
 
         [TestMethod]
         public void NoOsid_FallsBackToModuleAndDate()
         {
-            Assert.AreEqual(
-                "E38_" + Today,
-                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", null), null));
+            Assert.AreEqual("E38_" + Today + "_1", PackageStore.DefaultBaseName(PackageWith("E38", "PCM", null), null, this.dir));
         }
 
         [TestMethod]
         public void NoModuleType_FallsBackToControllerType()
         {
-            Assert.AreEqual(
-                "PCM_12628990_" + Today,
-                PackageStore.DefaultBaseName(PackageWith(null, "PCM", 12628990), null));
+            Assert.AreEqual("PCM_12628990_" + Today + "_1", PackageStore.DefaultBaseName(PackageWith(null, "PCM", 12628990), null, this.dir));
         }
 
         [TestMethod]
         public void NoPackageAtAll_StillProducesAUsableName()
         {
             // The Uno read picker runs before the read, so it has nothing to name the file after.
-            Assert.AreEqual("PCM_" + Today, PackageStore.DefaultBaseName(null, null));
+            Assert.AreEqual("PCM_" + Today + "_1", PackageStore.DefaultBaseName(null, null, this.dir));
         }
 
         [TestMethod]
         public void ModuleTypeWithPathCharacters_IsSanitized()
         {
             // Module type comes from the package manifest, so it is not guaranteed to be a legal name.
-            string name = PackageStore.DefaultBaseName(PackageWith(@"E38/bad:name", "PCM", 1), null);
+            string name = PackageStore.DefaultBaseName(PackageWith(@"E38/bad:name", "PCM", 1), null, this.dir);
             StringAssert.StartsWith(name, "E38_bad_name_1_");
-            foreach (char c in System.IO.Path.GetInvalidFileNameChars())
+            foreach (char c in Path.GetInvalidFileNameChars())
             {
                 Assert.IsFalse(name.IndexOf(c) >= 0, "Name still contains an invalid character.");
             }
@@ -77,9 +99,67 @@ namespace Tests
         [TestMethod]
         public void BlankPathIsTreatedAsUnsaved()
         {
-            Assert.AreEqual(
-                "E38_12628990_" + Today,
-                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", 12628990), "   "));
+            Assert.AreEqual("E38_12628990_" + Today + "_1", PackageStore.DefaultBaseName(E38, "   ", this.dir));
+        }
+
+        // ---- Sequence ----
+
+        [TestMethod]
+        public void SequenceSkipsNamesAlreadyOnDisk()
+        {
+            string stem = "E38_12628990_" + Today;
+            this.Touch(stem + "_1.phz");
+            Assert.AreEqual(stem + "_2", PackageStore.DefaultBaseName(E38, null, this.dir));
+
+            this.Touch(stem + "_2.phz");
+            Assert.AreEqual(stem + "_3", PackageStore.DefaultBaseName(E38, null, this.dir));
+        }
+
+        [TestMethod]
+        public void SequenceIsClaimedAcrossEverySupportedExtension()
+        {
+            // A .bin at sequence 1 must push a .phz save to 2, so one sequence number means one read
+            // whichever format it was saved in.
+            string stem = "E38_12628990_" + Today;
+            this.Touch(stem + "_1.bin");
+            Assert.AreEqual(stem + "_2", PackageStore.DefaultBaseName(E38, null, this.dir));
+        }
+
+        [TestMethod]
+        public void SequenceFillsTheFirstGap()
+        {
+            string stem = "E38_12628990_" + Today;
+            this.Touch(stem + "_1.phz");
+            this.Touch(stem + "_3.phz");
+            Assert.AreEqual(stem + "_2", PackageStore.DefaultBaseName(E38, null, this.dir));
+        }
+
+        [TestMethod]
+        public void UnrelatedFilesDoNotAdvanceTheSequence()
+        {
+            this.Touch("something else.phz");
+            this.Touch("E38_99999999_" + Today + "_1.phz");
+            Assert.AreEqual("E38_12628990_" + Today + "_1", PackageStore.DefaultBaseName(E38, null, this.dir));
+        }
+
+        [TestMethod]
+        public void UnknownDirectory_StillSequencesFromOne()
+        {
+            Assert.AreEqual("E38_12628990_" + Today + "_1", PackageStore.DefaultBaseName(E38, null, null));
+        }
+
+        [TestMethod]
+        public void MissingDirectory_DoesNotThrow()
+        {
+            string missing = Path.Combine(this.dir, "no such folder");
+            Assert.AreEqual("E38_12628990_" + Today + "_1", PackageStore.DefaultBaseName(E38, null, missing));
+        }
+
+        [TestMethod]
+        public void MalformedDirectory_DoesNotThrow()
+        {
+            // A bad setting must not be able to break saving.
+            Assert.AreEqual("E38_12628990_" + Today + "_1", PackageStore.DefaultBaseName(E38, null, "::::"));
         }
     }
 }

--- a/Apps/Tests/PackageNamingTests.cs
+++ b/Apps/Tests/PackageNamingTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-only
+using System;
+
+using PcmHacking;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests
+{
+    /// <summary>
+    /// Coverage for the default save-name rule (PackageStore.DefaultBaseName). It lives in the library
+    /// so every UI suggests the same file name; before that each front end invented its own, and one of
+    /// them handed its window-title text to the save dialog and produced "Untitled (unsaved read).phz".
+    /// </summary>
+    [TestClass]
+    public class PackageNamingTests
+    {
+        private static string Today => DateTime.Now.ToString("yyyyMMdd");
+
+        private static PcmPackage PackageWith(string? moduleType, string? type, uint? osid)
+        {
+            var controller = new PackageController { Id = 1, Type = type, ModuleType = moduleType };
+            controller.Images.Add(new PackageImage { Target = "main", FileName = "main.bin", Osid = osid });
+            return new PcmPackage { Controllers = { controller } };
+        }
+
+        [TestMethod]
+        public void UnsavedRead_UsesModuleOsidAndDate()
+        {
+            Assert.AreEqual(
+                "E38_12628990_" + Today,
+                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", 12628990), null));
+        }
+
+        [TestMethod]
+        public void AlreadySaved_KeepsExistingNameWithoutExtension()
+        {
+            Assert.AreEqual(
+                "my read",
+                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", 12628990), @"C:\bins\my read.phz"));
+        }
+
+        [TestMethod]
+        public void NoOsid_FallsBackToModuleAndDate()
+        {
+            Assert.AreEqual(
+                "E38_" + Today,
+                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", null), null));
+        }
+
+        [TestMethod]
+        public void NoModuleType_FallsBackToControllerType()
+        {
+            Assert.AreEqual(
+                "PCM_12628990_" + Today,
+                PackageStore.DefaultBaseName(PackageWith(null, "PCM", 12628990), null));
+        }
+
+        [TestMethod]
+        public void NoPackageAtAll_StillProducesAUsableName()
+        {
+            // The Uno read picker runs before the read, so it has nothing to name the file after.
+            Assert.AreEqual("PCM_" + Today, PackageStore.DefaultBaseName(null, null));
+        }
+
+        [TestMethod]
+        public void ModuleTypeWithPathCharacters_IsSanitized()
+        {
+            // Module type comes from the package manifest, so it is not guaranteed to be a legal name.
+            string name = PackageStore.DefaultBaseName(PackageWith(@"E38/bad:name", "PCM", 1), null);
+            StringAssert.StartsWith(name, "E38_bad_name_1_");
+            foreach (char c in System.IO.Path.GetInvalidFileNameChars())
+            {
+                Assert.IsFalse(name.IndexOf(c) >= 0, "Name still contains an invalid character.");
+            }
+        }
+
+        [TestMethod]
+        public void BlankPathIsTreatedAsUnsaved()
+        {
+            Assert.AreEqual(
+                "E38_12628990_" + Today,
+                PackageStore.DefaultBaseName(PackageWith("E38", "PCM", 12628990), "   "));
+        }
+    }
+}

--- a/Apps/Tests/Tests.csproj
+++ b/Apps/Tests/Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="ScanToolTests.cs" />
     <Compile Include="MathTests.cs" />
     <Compile Include="PackageFormatTests.cs" />
+    <Compile Include="PackageNamingTests.cs" />
     <Compile Include="FileValidatorTests.cs" />
     <Compile Include="UtilityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/ReadModel.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/ReadModel.cs
@@ -313,7 +313,10 @@ public partial record ReadModel : IAsyncLogger
         savePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
         savePicker.FileTypeChoices.Add("Binary", new List<string>() { ".bin" });
         savePicker.FileTypeChoices.Add("PcmHammer package", new List<string>() { ".phz" });
-        savePicker.SuggestedFileName = "Untitled.bin";
+        // Same naming rule as the other UIs. This picker runs before the read, so there is no package
+        // to take a module type and OSID from yet and the name is the date-stamped fallback; the rule
+        // still lives in the library rather than being spelled out again here.
+        savePicker.SuggestedFileName = PackageStore.DefaultBaseName(null, null) + ".bin";
         StorageFile file = await savePicker.PickSaveFileAsync();
         if (file == null)
         {

--- a/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/ReadModel.cs
+++ b/Apps/UI/UnoUI/PcmHacking.UnoUI/Presentation/ReadModel.cs
@@ -316,7 +316,7 @@ public partial record ReadModel : IAsyncLogger
         // Same naming rule as the other UIs. This picker runs before the read, so there is no package
         // to take a module type and OSID from yet and the name is the date-stamped fallback; the rule
         // still lives in the library rather than being spelled out again here.
-        savePicker.SuggestedFileName = PackageStore.DefaultBaseName(null, null) + ".bin";
+        savePicker.SuggestedFileName = PackageStore.DefaultBaseName(null, null, null) + ".bin";
         StorageFile file = await savePicker.PickSaveFileAsync();
         if (file == null)
         {

--- a/Apps/UI/WPF/PCMHammer/PCMHammer.csproj
+++ b/Apps/UI/WPF/PCMHammer/PCMHammer.csproj
@@ -19,6 +19,68 @@
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
+  <!--
+    Single-file packaging, on the same model as the Linux CLI: one self-contained .exe that
+    needs no .NET install on the target, with the kernels embedded (below) so there are no
+    loose .bin files to keep alongside it. A plain multi-file build is 53 files.
+
+    Gated on RuntimeIdentifier so it only engages for a RID-specific publish:
+
+        dotnet publish Apps/UI/WPF/PCMHammer/PCMHammer.csproj -c Release -r win-x86
+
+    Ordinary builds and F5 in Visual Studio set no RID, so they stay framework-dependent and
+    fast - none of this touches the inner development loop. win-x86 matches PlatformTarget
+    above: the app must be 32-bit to load 32-bit J2534 driver DLLs.
+  -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <!-- WPF ships native components (wpfgfx, PresentationNative, D3DCompiler, PenImc,
+         vcruntime). Without this they stay beside the exe and it is not a single file. -->
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <!-- Roughly halves the bundle (127 MB -> 59 MB); requires SelfContained. -->
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <!-- Trimming is off for the same reason as the Linux CLI: the dependency closure uses
+         runtime reflection (JSON/XML serialization, DynamicExpresso) and would break. -->
+    <PublishTrimmed>false</PublishTrimmed>
+    <!-- No .pdb next to the single exe. DebugType covers this project; the second property
+         covers the referenced ones (PcmLibrary, J2534DotNet, ...), whose .pdbs are copied in
+         as "reference related files" and would otherwise still land in the publish folder. -->
+    <DebugType>none</DebugType>
+    <AllowedReferenceRelatedFileExtensions>none</AllowedReferenceRelatedFileExtensions>
+  </PropertyGroup>
+
+  <!-- Embed the kernels into the executable, exactly as the Linux CLI does, so the single-file
+       build carries them internally. The kernel build scripts produce them into Kernels/build;
+       LogicalName flattens the resource name to the bare file name (e.g. "Kernel-P01.bin"),
+       which is what the loader matches on. A loose .bin next to the exe still wins over the
+       embedded copy, so a user can override an individual kernel without a rebuild. -->
+  <ItemGroup>
+    <KernelBinary Include="..\..\..\..\Kernels\build\*.bin" />
+    <EmbeddedResource Include="@(KernelBinary)">
+      <LogicalName>%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <!-- Boot loader support files, embedded the same way. SlaveLibrary prefers a loose file in a
+       SlaveLibrary folder next to the exe and falls back to the embedded copy. -->
+  <ItemGroup>
+    <SlaveLibraryBinary Include="..\..\WindowsForms\PcmHammer\SlaveLibrary\*.bin" />
+    <EmbeddedResource Include="@(SlaveLibraryBinary)">
+      <LogicalName>%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <!-- MSBuild expands the glob above before the build runs, so an empty Kernels/build yields a
+       binary with NO kernels embedded and nothing says so until it fails against a vehicle.
+       Report it at build time instead. -->
+  <Target Name="ReportEmbeddedKernels" BeforeTargets="CoreCompile">
+    <Warning Condition="'@(KernelBinary)' == ''"
+             Text="No kernels embedded: ..\..\..\..\Kernels\build\*.bin matched nothing. Build the kernels first (Kernels\BuildAll.cmd), otherwise this build only works with loose .bin files next to the exe." />
+    <Message Condition="'@(KernelBinary)' != ''" Importance="high"
+             Text="Embedding kernels: @(KernelBinary->'%(Filename)%(Extension)', ' ')" />
+  </Target>
+
   <Target Name="Date" BeforeTargets="CoreCompile">
     <!-- Writes Generated.BuildTime (the compile timestamp) so the About/log lines can show a
          "Build: <date time>" for untagged builds. BuildTicks can be passed in (/p:BuildTicks=...)

--- a/Apps/UI/WPF/PCMHammer/Services/PCMReader.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/PCMReader.cs
@@ -80,6 +80,47 @@ namespace PCMHammer.Services
             }
         }
 
+        /// <summary>
+        /// Read a PCM that is in recovery mode into an in-memory document, using the user-selected PCM
+        /// type. All the recovery rules live in the library (see PcmHacking.RecoveryMode).
+        /// </summary>
+        public async Task<PcmPackage?> RecoveryReadAsync(
+            PcmType pcmType,
+            CancellationToken cancellationToken = default)
+        {
+            using (new AwayMode())
+            {
+                try
+                {
+                    if (vehicle == null)
+                    {
+                        logger.AddUserMessage("Error: No vehicle interface connected.");
+                        return null;
+                    }
+
+                    ReadManager reader = new(
+                        logger,
+                        vehicle,
+                        (action) => {
+                            System.Windows.Application.Current.Dispatcher.Invoke(action);
+                            return Task.CompletedTask;
+                        },
+                        DummyPromptForFile!,
+                        DummyPromptForOsId!,
+                        Alert,
+                        PromptForYesNo,
+                        cancellationToken);
+
+                    return await reader.RecoveryRead(pcmType);
+                }
+                catch (Exception exception)
+                {
+                    logger.AddUserMessage($"Recovery read failed: {exception.Message}");
+                    return null;
+                }
+            }
+        }
+
         public async Task<bool> ReadPcmAsync(
             string path,
             bool useAutoPcmType = true,

--- a/Apps/UI/WPF/PCMHammer/Services/PcmFlasher.cs
+++ b/Apps/UI/WPF/PCMHammer/Services/PcmFlasher.cs
@@ -31,8 +31,7 @@ namespace PCMHammer.Services
             PcmPackage package,
             bool useAutoPcmType = true,
             PcmType selectedPcmType = PcmType.Undefined,
-            CancellationToken cancellationToken = default,
-            bool suppressOSIDWarning = false)
+            CancellationToken cancellationToken = default)
         {
             using (new AwayMode())
             {
@@ -56,7 +55,50 @@ namespace PCMHammer.Services
                         PromptForYesNo,
                         cancellationToken);
 
-                    return await writer.Write(package, forcedPcmType, suppressOSIDWarning);
+                    return await writer.Write(package, forcedPcmType);
+                }
+                catch (IOException exception)
+                {
+                    logger.AddUserMessage(exception.ToString());
+                    return false;
+                }
+                finally
+                {
+                    _currentWriteType = WriteType.None;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write the loaded document to a PCM that is in recovery mode, using the user-selected PCM
+        /// type. All the recovery rules live in the library (see PcmHacking.RecoveryMode).
+        /// </summary>
+        public async Task<bool> RecoveryWriteAsync(
+            PcmPackage package,
+            PcmType pcmType,
+            CancellationToken cancellationToken = default)
+        {
+            using (new AwayMode())
+            {
+                try
+                {
+                    _currentWriteType = WriteType.Full;
+
+                    if (vehicle == null)
+                    {
+                        logger.AddUserMessage("Error: No vehicle interface connected.");
+                        return false;
+                    }
+
+                    WriteManager writer = new(
+                        logger,
+                        vehicle,
+                        WriteType.Full,
+                        Alert,
+                        PromptForYesNo,
+                        cancellationToken);
+
+                    return await writer.RecoveryWrite(package, pcmType);
                 }
                 catch (IOException exception)
                 {
@@ -75,8 +117,7 @@ namespace PCMHammer.Services
             string path,
             bool useAutoPcmType = true,
             PcmType selectedPcmType = PcmType.Undefined,
-            CancellationToken cancellationToken = default,
-            bool suppressOSIDWarning = false
+            CancellationToken cancellationToken = default
             )
         {
             using (new AwayMode())
@@ -104,7 +145,7 @@ namespace PCMHammer.Services
                         cancellationToken
                     );
 
-                    bool success = await writer.Write(path, forcedPcmType, suppressOSIDWarning);
+                    bool success = await writer.Write(path, forcedPcmType);
                     
                     return success;
                 }

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/ChangeVINViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/ChangeVINViewModel.cs
@@ -37,10 +37,14 @@ namespace PCMHammer.Viewmodels
         #endregion
 
         #region Commands
+        // Do NOT name these methods "...Command": the generator appends "Command" to the method
+        // name, so OkCommand() produced OkCommandCommand and the XAML binding to OkCommand
+        // silently resolved to nothing - OK did nothing at all, and Cancel only appeared to work
+        // because IsCancel="True" closes the dialog by itself. Same trap as WriteTypeViewModel.
         [RelayCommand(CanExecute = nameof(IsValid))]
-        public void OkCommand() => RequestCloseOk?.Invoke();
+        public void Ok() => RequestCloseOk?.Invoke();
         [RelayCommand]
-        public void CancelCommand() => RequestCloseCancel?.Invoke();
+        public void Cancel() => RequestCloseCancel?.Invoke();
         #endregion
 
         public ChangeVinViewModel(string initialVin)

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/DelayViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/DelayViewModel.cs
@@ -8,20 +8,29 @@ namespace PCMHammer.Viewmodels
 {
     public partial class DelayViewModel : ObservableObject
     {
+        private const int CountdownSeconds = 10;
+
         // Properties
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(TimerText))]
-        public partial int TimerValue { get; set; } = 10;
+        public partial int TimerValue { get; set; } = CountdownSeconds;
 
-        [ObservableProperty]
-        public partial string TimerText { get; set; } = "10 seconds remaining...";
+        // Computed, not stored: as a stored [ObservableProperty] this held its initial string
+        // forever, so the dialog always read "10 seconds remaining..." and never counted down.
+        // NotifyPropertyChangedFor on TimerValue re-raises this, which only does something when
+        // there is a getter to re-evaluate.
+        public string TimerText => TimerValue == 1
+            ? "1 second remaining..."
+            : $"{TimerValue} seconds remaining...";
 
         // Events
         public event Action? RequestClose;
 
-        // Commands
+        // Commands. Do NOT name this method "CloseCommand": the generator appends "Command" to the
+        // method name, so CloseCommand() produces CloseCommandCommand and the XAML binding to
+        // CloseCommand silently resolves to nothing. See WriteTypeViewModel for the same trap.
         [RelayCommand]
-        public void CloseCommand()
+        public void Close()
         {
             _waitTimer.Stop();
             RequestClose?.Invoke();
@@ -34,7 +43,8 @@ namespace PCMHammer.Viewmodels
             _waitTimer.Tick += (s, e) =>
             {
                 if (TimerValue > 0) TimerValue--;
-                else
+
+                if (TimerValue == 0)
                 {
                     _waitTimer.Stop();
                     RequestClose?.Invoke();
@@ -42,5 +52,11 @@ namespace PCMHammer.Viewmodels
             };
             _waitTimer.Start();
         }
+
+        /// <summary>
+        /// Stops the countdown. Called when the dialog closes by any route, so a timer belonging to
+        /// a dismissed dialog cannot keep ticking and raise RequestClose against a closed window.
+        /// </summary>
+        public void StopTimer() => _waitTimer.Stop();
     }
 }

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
@@ -153,7 +153,7 @@ namespace PCMHammer.Viewmodels
                 return;
             }
 
-            string? basePath = _fileDialogService.ExportBinBaseDialog(DocumentDisplayName());
+            string? basePath = _fileDialogService.ExportBinBaseDialog(DefaultSaveName());
             if (basePath == null)
             {
                 return;
@@ -280,7 +280,7 @@ namespace PCMHammer.Viewmodels
 
             if (path == null)
             {
-                path = _fileDialogService.SavePackageFileDialog(complete, DocumentDisplayName());
+                path = _fileDialogService.SavePackageFileDialog(complete, DefaultSaveName());
                 if (path == null)
                 {
                     return false;
@@ -378,8 +378,19 @@ namespace PCMHammer.Viewmodels
         }
 
         /// <summary>The display file name for the working document (falls back to an unsaved-read label).</summary>
+        /// <remarks>
+        /// Window/status text only. Do NOT use it to seed a save dialog - that is what produced files
+        /// called "Untitled (unsaved read).phz". Use <see cref="DefaultSaveName"/> for that.
+        /// </remarks>
         private string DocumentDisplayName() =>
             LoadedPackagePath != null ? Path.GetFileName(LoadedPackagePath) : "Untitled (unsaved read)";
+
+        /// <summary>
+        /// The base file name to suggest when saving. The rule lives in the library so every UI
+        /// suggests the same thing; a null path is what asks it to build one from the package.
+        /// </summary>
+        private string DefaultSaveName() =>
+            PackageStore.DefaultBaseName(LoadedPackage, LoadedPackagePath);
 
         /// <summary>One-line summary of a package: module type, OSID, and whether it carries the slave.</summary>
         private static string DescribeDocument(PcmPackage package)

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.Document.cs
@@ -390,7 +390,11 @@ namespace PCMHammer.Viewmodels
         /// suggests the same thing; a null path is what asks it to build one from the package.
         /// </summary>
         private string DefaultSaveName() =>
-            PackageStore.DefaultBaseName(LoadedPackage, LoadedPackagePath);
+            PackageStore.DefaultBaseName(
+                LoadedPackage,
+                LoadedPackagePath,
+                // The folder the save dialogs open in, so the sequence number skips names already there.
+                Properties.Settings.Default.BinDirectory);
 
         /// <summary>One-line summary of a package: module type, OSID, and whether it carries the slave.</summary>
         private static string DescribeDocument(PcmPackage package)

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
@@ -58,7 +58,16 @@ namespace PCMHammer.Viewmodels
         public partial string TimeRemaining { get; set; } = "00:00 Remaining";
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(DeviceDescription))]
         public partial Vehicle? Vehicle { get; set; }
+
+        /// <summary>
+        /// The connected interface, shown on the main window the way WinForms shows it in its
+        /// Device box. The text comes from the library (Vehicle.DeviceDescription -> Device
+        /// .ToString()), which is the same source MainFormBase hands to WinForms, so every front
+        /// end names a device identically and none of them format it themselves.
+        /// </summary>
+        public string DeviceDescription => Vehicle?.DeviceDescription ?? "No device selected.";
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(CanStartOperation))]
@@ -587,7 +596,8 @@ namespace PCMHammer.Viewmodels
                 {
                     string cleanVin = vinViewModel.Vin.Trim();
                     _logger.AddUserMessage($"Attempting to write updated VIN: {cleanVin}");
-                    bool unlocked = await Vehicle.UnlockEcu(info.KeyAlgorithm);
+                    // No cancellation source in the VIN flow; the unlock is bounded by its own time budget.
+                    bool unlocked = await Vehicle.UnlockEcu(info.KeyAlgorithm, CancellationToken.None);
                     if (!unlocked)
                     {
                         _logger.AddUserMessage("Unable to unlock PCM. Authorization Denied.");

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/MainWindowViewModel.cs
@@ -108,6 +108,8 @@ namespace PCMHammer.Viewmodels
             WriteOSCalibrationBootCommand.NotifyCanExecuteChanged();
             WriteFullFlashCloneCommand.NotifyCanExecuteChanged();
             ChangeVINCommand.NotifyCanExecuteChanged();
+            RecoveryReadCommand.NotifyCanExecuteChanged();
+            RecoveryWriteCommand.NotifyCanExecuteChanged();
             TestFileChecksumsCommand.NotifyCanExecuteChanged();
             BruteForceUnlockCommand.NotifyCanExecuteChanged();
             HaltRunningKernelCommand.NotifyCanExecuteChanged();
@@ -156,6 +158,10 @@ namespace PCMHammer.Viewmodels
         public async Task VerifyPCM() => await ExecuteVerificationAsync();
         [RelayCommand(CanExecute = nameof(CanStartOperation))]
         public async Task ChangeVIN() => await ExecuteChangeVINAsync();
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
+        public async Task RecoveryRead() => await ExecuteRecoveryReadAsync();
+        [RelayCommand(CanExecute = nameof(CanStartOperation))]
+        public async Task RecoveryWrite() => await ExecuteRecoveryWriteAsync();
         [RelayCommand(CanExecute = nameof(CanWriteDocument))]
         public async Task WriteParameters() => await ExecuteWritePCMAsync(WriteType.Parameters);
         [RelayCommand(CanExecute = nameof(CanWriteDocument))]
@@ -724,7 +730,7 @@ namespace PCMHammer.Viewmodels
 
             return false; // Failed or timed out; needs UI fallback
         }
-        private async Task ExecuteWritePCMAsync(WriteType writeType, PcmType pcmType = PcmType.Undefined, bool suppressOSIDWarning = false)
+        private async Task ExecuteWritePCMAsync(WriteType writeType, PcmType pcmType = PcmType.Undefined)
         {
             if (Vehicle == null) return;
             if (PcmFlasher == null) return;
@@ -756,7 +762,7 @@ namespace PCMHammer.Viewmodels
 
                     // Task.Run guarantees it completely leaves the UI thread.
                     bool success = await Task.Run(() =>
-                        PcmFlasher.WritePackageAsync(writeType, document, useAutoPcmType, pcmType, _cancellationTokenSource.Token, suppressOSIDWarning)
+                        PcmFlasher.WritePackageAsync(writeType, document, useAutoPcmType, pcmType, _cancellationTokenSource.Token)
                     );
 
                     StatusText = success ? "Write Operation Completed." : "Write Operation Failed.";
@@ -778,12 +784,149 @@ namespace PCMHammer.Viewmodels
                 }
             }
         }
+        /// <summary>
+        /// PCM Recovery -> Read. Asks which PCM is on the bench, then reads it straight through the
+        /// recovery path (no detection). The result replaces the working document, exactly like a
+        /// normal read.
+        /// </summary>
+        private async Task ExecuteRecoveryReadAsync()
+        {
+            if (Vehicle == null || PcmReader == null || IsOperationRunning) return;
+
+            PcmType? pcmType = PromptForRecoveryPcmType();
+            if (pcmType == null) return;
+
+            // Same document rules as a normal read: don't silently discard unsaved changes.
+            if (!ConfirmDiscardIfDirty()) return;
+
+            try
+            {
+                IsOperationRunning = true;
+                StatusText = "Recovery read...";
+                _cancellationTokenSource = new CancellationTokenSource();
+
+                PcmPackage? package = await Task.Run(() =>
+                    PcmReader.RecoveryReadAsync(pcmType.Value, _cancellationTokenSource.Token));
+
+                if (package != null)
+                {
+                    SetLoadedPackage(package, path: null, dirty: true);
+                    StatusText = "Recovery read completed.";
+                    PromptSaveAfterRead();
+                }
+                else
+                {
+                    StatusText = "Recovery read failed.";
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.AddUserMessage($"Recovery read failed: {ex.Message}");
+                StatusText = "Error occurred.";
+            }
+            finally
+            {
+                IsOperationRunning = false;
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+
+                await Task.Delay(2000);
+                if (!IsOperationRunning) StatusText = "Ready";
+            }
+        }
+
+        /// <summary>
+        /// PCM Recovery -> Write. Writes the loaded document straight through the recovery path (no
+        /// detection), using the PCM type the user selects. Because recovery bypasses detection, we
+        /// confirm exactly which file is about to be written first.
+        /// </summary>
+        private async Task ExecuteRecoveryWriteAsync()
+        {
+            if (Vehicle == null || PcmFlasher == null || IsOperationRunning) return;
+
+            PcmPackage? document = LoadedPackage;
+            if (document == null)
+            {
+                const string message =
+                    "No file is loaded.\n\nLoad the .phz or .bin you want to write (File -> Load File) "
+                    + "before running a recovery write.";
+                _logger.AddUserMessage("Recovery write: no file loaded.");
+                MessageBox.Show(message, "PCM Recovery", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            PcmType? pcmType = PromptForRecoveryPcmType();
+            if (pcmType == null) return;
+
+            // Recovery skips every detection cross-check, so make sure the user knows which file this
+            // is about to put on the PCM.
+            string confirmation =
+                $"Recovery write to a {pcmType.Value} PCM.\n\n" +
+                $"File: {DocumentDisplayName()}\n" +
+                $"{DescribeDocument(document)}\n\n" +
+                "The PCM will NOT be detected or verified first. Write this file now?";
+            if (MessageBox.Show(confirmation, "Confirm recovery write",
+                    MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
+            {
+                _logger.AddUserMessage("Recovery write canceled by user.");
+                return;
+            }
+
+            try
+            {
+                IsOperationRunning = true;
+                StatusText = "Recovery write...";
+                _cancellationTokenSource = new CancellationTokenSource();
+
+                bool success = await Task.Run(() =>
+                    PcmFlasher.RecoveryWriteAsync(document, pcmType.Value, _cancellationTokenSource.Token));
+
+                StatusText = success ? "Recovery write completed." : "Recovery write failed.";
+            }
+            catch (Exception ex)
+            {
+                _logger.AddUserMessage($"Recovery write failed: {ex.Message}");
+                StatusText = "Error occurred.";
+            }
+            finally
+            {
+                IsOperationRunning = false;
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+
+                await Task.Delay(2000);
+                if (!IsOperationRunning) StatusText = "Ready";
+            }
+        }
+
+        /// <summary>
+        /// Ask which PCM is being recovered. Null when the user cancels. Recovery cannot auto-detect
+        /// the type, so "Auto" is rejected here rather than deeper in the flow.
+        /// </summary>
+        private PcmType? PromptForRecoveryPcmType()
+        {
+            PcmTypeSelectDialogBox dialog = new() { Owner = _parentWindow };
+            if (dialog.ShowDialog() != true)
+            {
+                return null;
+            }
+
+            if (!RecoveryMode.CanAttempt(dialog.SelectedPCMType, out string reason))
+            {
+                _logger.AddUserMessage(reason);
+                MessageBox.Show(reason, "PCM Recovery", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return null;
+            }
+
+            return dialog.SelectedPCMType;
+        }
+
         private async Task ExecuteWritePCMAsyncWithDialog()
         {
             WriteOperationDialogBox dialog = new() { Owner = Application.Current.MainWindow };
             if (dialog.ShowDialog() == true)
             {
-                await ExecuteWritePCMAsync(dialog.SelectedWriteType, dialog.SelectedPCMType, dialog.SuppressOSIDWarning);
+                await ExecuteWritePCMAsync(dialog.SelectedWriteType, dialog.SelectedPCMType);
             }
         }
         private async Task ExecuteCancelCurrentOperationAsync()

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/WriteTypeViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/WriteTypeViewModel.cs
@@ -39,6 +39,16 @@ namespace PCMHammer.Viewmodels
             WriteTypes = [WriteType.Full, WriteType.OsPlusCalibrationPlusBoot, WriteType.Parameters];
 
             PCMTypes = [.. Enum.GetValues<PcmType>()];
+
+            // Seed the selections here rather than with ComboBox.SelectedIndex in the view. Setting
+            // SelectedIndex right after DataContext is timing-dependent: if ItemsSource has not been
+            // populated at that instant the assignment silently does nothing, SelectedIndex stays -1,
+            // and these properties keep their CLR defaults. For WriteType that default is
+            // WriteType.None (= 0), which is not a real operation - it survived all the way into
+            // CanKernelWriter and threw "Unsuppported operation type: None" only AFTER the kernel had
+            // been uploaded and was running on the PCM.
+            SelectedWriteType = WriteTypes[0];   // Clone (Full Flash)
+            SelectedPCMType = PcmType.Undefined; // Auto (Query OSID)
         }
     }
 }

--- a/Apps/UI/WPF/PCMHammer/Viewmodels/WriteTypeViewModel.cs
+++ b/Apps/UI/WPF/PCMHammer/Viewmodels/WriteTypeViewModel.cs
@@ -18,20 +18,20 @@ namespace PCMHammer.Viewmodels
         [ObservableProperty]
         public partial PcmType SelectedPCMType { get; set; }
 
-        // TODO: This property will be used to silence the brick warning when using the "reset pin" to bypass the standard initialization sequence
-        [ObservableProperty]
-        public partial bool SuppressOSIDWarning { get; set; }
         #endregion
 
         // Events
         public event Action? RequestClose;
         public event Action? RequestAcceptandClose;
 
-        // Commands
+        // Commands. Do NOT name these methods "...Command": the generator appends "Command" to the
+        // method name, so CloseCommand() would produce CloseCommandCommand and the XAML binding to
+        // CloseCommand would silently resolve to nothing (which is why OK did nothing - Cancel only
+        // appeared to work because IsCancel="True" closes the dialog by itself).
         [RelayCommand]
-        public void CloseCommand() => RequestClose?.Invoke();
+        public void Close() => RequestClose?.Invoke();
         [RelayCommand]
-        public void AcceptAndCloseCommand() => RequestAcceptandClose?.Invoke();
+        public void AcceptAndClose() => RequestAcceptandClose?.Invoke();
 
         // Constructor
         public WriteTypeViewModel()

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/DelayDialogBox.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/DelayDialogBox.xaml
@@ -30,8 +30,11 @@
         <TextBlock Grid.Row="1" Text="{Binding TimerText}" d:Text="10 seconds remaining..." Margin="0,5" FontStyle="Italic" Opacity="0.5" HorizontalAlignment="Center"/>
 
         <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Right" Margin="0,5">
-            <Button Grid.Row="2" Content="Skip"   HorizontalAlignment="Right" Width="100" Margin="5" 
-                    IsCancel="True" Command="{Binding CloseCommand}"/>
+            <!-- No IsCancel here: it made the button set DialogResult=false and close by itself,
+                 so "Skip" silently ABORTED the write instead of proceeding. The command is the
+                 only thing that should dismiss this dialog. -->
+            <Button Grid.Row="2" Content="Skip"   HorizontalAlignment="Right" Width="100" Margin="5"
+                    Command="{Binding CloseCommand}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/DelayDialogBox.xaml.cs
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/DelayDialogBox.xaml.cs
@@ -16,10 +16,18 @@ namespace PCMHammer.Views
             InitializeComponent();
             _viewModel = new DelayViewModel();
             DataContext = _viewModel;
-            _viewModel.RequestClose += Cancel;
+            _viewModel.RequestClose += Proceed;
+            // Whatever dismisses the dialog (Skip, countdown, or the title bar X), the timer must
+            // not outlive it.
+            Closed += (s, e) => _viewModel.StopTimer();
         }
 
-        private void Cancel()
+        /// <summary>
+        /// The countdown finished, or the user chose to skip the remaining wait. Both mean "go
+        /// ahead", so the caller (which gates the write on ShowDialog() == true) proceeds.
+        /// Closing the dialog any other way leaves DialogResult null and cancels the operation.
+        /// </summary>
+        private void Proceed()
         {
             DialogResult = true;
             Close();

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/WriteOperationDialogBox.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/WriteOperationDialogBox.xaml
@@ -18,7 +18,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Label Content="PCM Type" VerticalAlignment="Center" Target="{Binding ElementName=PCMTypeComboBox}"/>
@@ -59,11 +58,7 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
         
-        <Label Content="Rest Pin Used" VerticalAlignment="Center" Grid.Row="2" Target="{Binding ElementName=PCMRestPinCheckBox}"/>
-        <CheckBox x:Name="PCMRestPinCheckBox" Grid.Row="2" Grid.Column="1" Margin="10,5"
-                  IsChecked="{Binding SuppressOSIDWarning, Mode=TwoWay}"/>
-
-        <Grid Grid.Column="1" Grid.Row="3" Margin="10,5">
+        <Grid Grid.Column="1" Grid.Row="2" Margin="10,5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/WriteOperationDialogBox.xaml.cs
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/WriteOperationDialogBox.xaml.cs
@@ -26,13 +26,6 @@ namespace PCMHammer.Views.DialogBoxes
             set => _selectedWriteType = value;
         }
 
-        private bool _suppressOSIDWarning;
-        public bool SuppressOSIDWarning
-        {
-            get => _suppressOSIDWarning;
-            set => _suppressOSIDWarning = value;
-        }
-
         public WriteOperationDialogBox()
         {
             InitializeComponent();
@@ -48,7 +41,6 @@ namespace PCMHammer.Views.DialogBoxes
         {
             SelectedPCMType = _viewModel.SelectedPCMType;
             SelectedWriteType = _viewModel.SelectedWriteType;
-            SuppressOSIDWarning = _viewModel.SuppressOSIDWarning;
             DialogResult = true;
             Close();
         }

--- a/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/WriteOperationDialogBox.xaml.cs
+++ b/Apps/UI/WPF/PCMHammer/Views/DialogBoxes/WriteOperationDialogBox.xaml.cs
@@ -31,8 +31,8 @@ namespace PCMHammer.Views.DialogBoxes
             InitializeComponent();
             _viewModel = new WriteTypeViewModel();
             DataContext = _viewModel;
-            PCMTypeComboBox.SelectedIndex = 0;
-            WriteTypeComboBox.SelectedIndex = 0;
+            // The initial selections come from the view model's constructor, not from
+            // ComboBox.SelectedIndex here - see WriteTypeViewModel for why that was unreliable.
             _viewModel.RequestClose += () => Close();
             _viewModel.RequestAcceptandClose += AcceptAndClose;
         }

--- a/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
@@ -67,6 +67,9 @@
             <StackPanel>
                 <GroupBox Header="Device">
                     <StackPanel>
+                        <!-- Which interface is connected, matching the WinForms Device box. -->
+                        <TextBlock Text="{Binding DeviceDescription}" TextWrapping="Wrap" FontSize="11"
+                                   Opacity="0.8" Margin="0,0,0,5"/>
                         <Button Content="_Select Device"
                                 Command="{Binding SelectDeviceCommand}"
                                 CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"

--- a/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
+++ b/Apps/UI/WPF/PCMHammer/Views/MainWindow.xaml
@@ -40,6 +40,13 @@
                 <MenuItem Header="Write _OS, Calibration &amp; Boot" Command="{Binding WriteOSCalibrationBootCommand}"/>
                 <MenuItem Header="Write _Full Flash (Clone)" Command="{Binding WriteFullFlashCloneCommand}"/>
                 <Separator Height="2"/>
+                <!-- Recovery: for a PCM held in its boot loader (reset/recovery pin grounded). It
+                     reports no OSID, so the user names the type and we skip detection entirely. -->
+                <MenuItem Header="PCM _Recovery">
+                    <MenuItem Header="_Read..."  Command="{Binding RecoveryReadCommand}"/>
+                    <MenuItem Header="_Write..." Command="{Binding RecoveryWriteCommand}"/>
+                </MenuItem>
+                <Separator Height="2"/>
                 <MenuItem Header="_Test File Checksums..." Command="{Binding TestFileChecksumsCommand}"/>
                 <MenuItem Header="Brute Force _Unlock..." Command="{Binding BruteForceUnlockCommand}"/>
                 <Separator Height="2"/>

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.Designer.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.Designer.cs
@@ -1,4 +1,4 @@
-namespace PcmHacking
+﻿namespace PcmHacking
 {
     partial class MainForm
     {
@@ -81,6 +81,9 @@ namespace PcmHacking
             this.bruteForceUnlockToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.busMonitorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.haltRunningKernelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pcmRecoveryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.recoveryReadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.recoveryWriteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuItemOptions = new System.Windows.Forms.ToolStripMenuItem();
             this.userDefinedKeyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -539,6 +542,7 @@ namespace PcmHacking
             this.writeOSCalibrationBootToolStripMenuItem,
             this.writeFullToolStripMenuItem,
             this.toolStripSeparator2,
+            this.pcmRecoveryToolStripMenuItem,
             this.testFileChecksumsToolStripMenuItem,
             this.bruteForceUnlockToolStripMenuItem,
             this.busMonitorToolStripMenuItem,
@@ -617,6 +621,29 @@ namespace PcmHacking
             this.busMonitorToolStripMenuItem.Text = "Bus &Monitor";
             this.busMonitorToolStripMenuItem.ToolTipText = "Show the Bus Monitor tab and switch to it.";
             this.busMonitorToolStripMenuItem.Click += new System.EventHandler(this.busMonitorToolStripMenuItem_Click);
+            //
+            // pcmRecoveryToolStripMenuItem
+            //
+            this.pcmRecoveryToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.recoveryReadToolStripMenuItem,
+            this.recoveryWriteToolStripMenuItem});
+            this.pcmRecoveryToolStripMenuItem.Name = "pcmRecoveryToolStripMenuItem";
+            this.pcmRecoveryToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.pcmRecoveryToolStripMenuItem.Text = "PCM &Recovery";
+            //
+            // recoveryReadToolStripMenuItem
+            //
+            this.recoveryReadToolStripMenuItem.Name = "recoveryReadToolStripMenuItem";
+            this.recoveryReadToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.recoveryReadToolStripMenuItem.Text = "&Read...";
+            this.recoveryReadToolStripMenuItem.Click += new System.EventHandler(this.recoveryReadToolStripMenuItem_Click);
+            //
+            // recoveryWriteToolStripMenuItem
+            //
+            this.recoveryWriteToolStripMenuItem.Name = "recoveryWriteToolStripMenuItem";
+            this.recoveryWriteToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.recoveryWriteToolStripMenuItem.Text = "&Write...";
+            this.recoveryWriteToolStripMenuItem.Click += new System.EventHandler(this.recoveryWriteToolStripMenuItem_Click);
             //
             // haltRunningKernelToolStripMenuItem
             //
@@ -826,6 +853,9 @@ namespace PcmHacking
         private System.Windows.Forms.ToolStripMenuItem bruteForceUnlockToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem busMonitorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem haltRunningKernelToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem pcmRecoveryToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem recoveryReadToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem recoveryWriteToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
     }

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
@@ -814,21 +814,12 @@ namespace PcmHacking
         }
 
         /// <summary>
-        /// A default base file name for the working document: the current file's name if it has one,
-        /// otherwise built from the module type and OSID of a freshly-read PCM (e.g. "E38_12628990").
+        /// A default base file name for the working document. The rule lives in the library
+        /// (<see cref="PackageStore.DefaultBaseName"/>) so every UI suggests the same name; passing a
+        /// null path is what asks it to build one from the package.
         /// </summary>
-        private string DefaultDocumentBaseName()
-        {
-            if (this.loadedPackagePath != null)
-            {
-                return Path.GetFileNameWithoutExtension(this.loadedPackagePath);
-            }
-
-            PackageController? controller = this.loadedPackage?.Controllers.FirstOrDefault();
-            string module = controller?.ModuleType ?? controller?.Type ?? "PCM";
-            uint? osid = controller?.Image("main")?.Osid;
-            return osid != null ? module + "_" + osid : module;
-        }
+        private string DefaultDocumentBaseName() =>
+            PackageStore.DefaultBaseName(this.loadedPackage, this.loadedPackagePath);
 
         /// <summary>
         /// Save dialog that supplies the folder and base name for an export. The exporter appends the PCM
@@ -848,10 +839,7 @@ namespace PcmHacking
                 {
                     dialog.InitialDirectory = Configuration.Settings.BinDirectory;
                 }
-                if (this.loadedPackagePath != null)
-                {
-                    dialog.FileName = Path.GetFileNameWithoutExtension(this.loadedPackagePath);
-                }
+                dialog.FileName = this.DefaultDocumentBaseName();
                 return dialog.ShowDialog() == DialogResult.OK ? dialog.FileName : null;
             }
         }
@@ -1514,7 +1502,8 @@ namespace PcmHacking
 
                 if (dialogResult == DialogResult.OK)
                 {
-                    bool unlocked = await this.Vehicle.UnlockEcu(info.KeyAlgorithm);
+                    // No cancellation source in the VIN flow; the unlock is bounded by its own time budget.
+                    bool unlocked = await this.Vehicle.UnlockEcu(info.KeyAlgorithm, CancellationToken.None);
                     if (!unlocked)
                     {
                         this.AddUserMessage("Unable to unlock PCM.");

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
@@ -1629,6 +1629,106 @@ namespace PcmHacking
             }
         }
 
+        /// <summary>
+        /// Tools -> PCM Recovery -> Read. Reads a PCM held in its boot loader (recovery/reset pin
+        /// grounded). Such a PCM reports no operating system, so the user names the type and we skip
+        /// detection entirely.
+        /// </summary>
+        private void recoveryReadToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (BackgroundWorker.IsAlive || this.Vehicle == null)
+            {
+                return;
+            }
+
+            PcmType? pcmType = this.PromptForRecoveryPcmType();
+            if (pcmType == null)
+            {
+                return;
+            }
+
+            // Same document rules as a normal read: don't silently discard unsaved changes.
+            if (!this.ConfirmDiscardIfDirty())
+            {
+                return;
+            }
+
+            BackgroundWorker = new System.Threading.Thread(
+                () => readFullContents_BackgroundThread(false, pcmType.Value, recovery: true));
+            BackgroundWorker.IsBackground = true;
+            BackgroundWorker.Start();
+        }
+
+        /// <summary>
+        /// Tools -> PCM Recovery -> Write. Writes the loaded working document to a PCM held in its boot
+        /// loader. Recovery skips every detection cross-check, so the file is confirmed with the user
+        /// first. The boot-sector protection still applies inside the writer.
+        /// </summary>
+        private void recoveryWriteToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (BackgroundWorker.IsAlive || this.Vehicle == null)
+            {
+                return;
+            }
+
+            if (this.loadedPackage == null)
+            {
+                string message =
+                    "No file is loaded." + Environment.NewLine + Environment.NewLine +
+                    "Load the .phz or .bin you want to write (File -> Load File) before running a recovery write.";
+                this.AddUserMessage("Recovery write: no file loaded.");
+                MessageBox.Show(this, message, "PCM Recovery", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            PcmType? pcmType = this.PromptForRecoveryPcmType();
+            if (pcmType == null)
+            {
+                return;
+            }
+
+            string confirmation =
+                "Recovery write to a " + pcmType.Value + " PCM." + Environment.NewLine + Environment.NewLine +
+                "File: " + (this.loadedPackagePath != null ? Path.GetFileName(this.loadedPackagePath) : "Untitled (unsaved read)") + Environment.NewLine +
+                Environment.NewLine +
+                "The PCM will NOT be detected or verified first. Write this file now?";
+            if (MessageBox.Show(this, confirmation, "Confirm recovery write",
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+            {
+                this.AddUserMessage("Recovery write canceled by user.");
+                return;
+            }
+
+            BackgroundWorker = new System.Threading.Thread(
+                () => write_BackgroundThread(WriteType.Full, null, false, pcmType.Value, recovery: true));
+            BackgroundWorker.IsBackground = true;
+            BackgroundWorker.Start();
+        }
+
+        /// <summary>
+        /// Ask which PCM is being recovered. Null when the user cancels or picks something recovery
+        /// cannot handle (the rules live in the shared PcmHacking.RecoveryMode).
+        /// </summary>
+        private PcmType? PromptForRecoveryPcmType()
+        {
+            using (PcmTypeSelectorDialogBox dialog = new PcmTypeSelectorDialogBox())
+            {
+                if (dialog.ShowDialog(this) != DialogResult.OK)
+                {
+                    return null;
+                }
+
+                if (!RecoveryMode.CanAttempt(dialog.SelectedPcmType, out string reason))
+                {
+                    this.AddUserMessage(reason);
+                    MessageBox.Show(this, reason, "PCM Recovery", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return null;
+                }
+
+                return dialog.SelectedPcmType;
+            }
+        }
+
         private async void StartOperationFromDialog(bool defaultIsWrite, WriteType defaultWriteType)
         {
             // Probe the bus first so the dialog can offer only the write types this PCM supports and
@@ -1881,7 +1981,11 @@ namespace PcmHacking
         /// <summary>
         /// Read the entire contents of the flash.
         /// </summary>
-        private async void readFullContents_BackgroundThread(bool useAutoPcmType = true, PcmType selectedPcmType = PcmType.Undefined)
+        /// <param name="recovery">
+        /// True for a PCM Recovery read: the selected PCM type is used as-is and detection, the OSID
+        /// query and the kernel probe are all skipped. See PcmHacking.RecoveryMode.
+        /// </param>
+        private async void readFullContents_BackgroundThread(bool useAutoPcmType = true, PcmType selectedPcmType = PcmType.Undefined, bool recovery = false)
         {
             using (new AwayMode())
             {
@@ -1915,7 +2019,9 @@ namespace PcmHacking
 
                     // Read into the in-memory working document (unsaved). The user saves it via the prompt
                     // below or the Save File button; Write flashes it directly - no file needed in between.
-                    PcmPackage? package = await readManager.ReadToPackage(forcedPcmType);
+                    PcmPackage? package = recovery
+                        ? await readManager.RecoveryRead(selectedPcmType)
+                        : await readManager.ReadToPackage(forcedPcmType);
                     if (package != null)
                     {
                         this.loadedPackage = package;
@@ -1989,7 +2095,12 @@ namespace PcmHacking
         /// <summary>
         /// Write changes to the PCM's flash memory.
         /// </summary>
-        private async void write_BackgroundThread(WriteType writeType, string? path = null, bool useAutoPcmType = true, PcmType selectedPcmType = PcmType.Undefined)
+        /// <param name="recovery">
+        /// True for a PCM Recovery write: the selected PCM type is used as-is and detection, the OSID
+        /// query and the kernel probe are all skipped. The boot-sector protection still applies. See
+        /// PcmHacking.RecoveryMode.
+        /// </param>
+        private async void write_BackgroundThread(WriteType writeType, string? path = null, bool useAutoPcmType = true, PcmType selectedPcmType = PcmType.Undefined, bool recovery = false)
         {
             using (new AwayMode())
             {
@@ -2051,9 +2162,19 @@ namespace PcmHacking
                         this.PromptForYesNo,
                         this.cancellationTokenSource.Token);
 
-                    bool success = document != null
-                        ? await writer.Write(document, forcedPcmType)
-                        : await writer.Write(path!, forcedPcmType);
+                    bool success;
+                    if (recovery)
+                    {
+                        // Recovery always writes the loaded working document; the caller has already
+                        // checked one is loaded and confirmed it with the user.
+                        success = await writer.RecoveryWrite(document!, selectedPcmType);
+                    }
+                    else
+                    {
+                        success = document != null
+                            ? await writer.Write(document, forcedPcmType)
+                            : await writer.Write(path!, forcedPcmType);
+                    }
 
                     if (success)
                     {

--- a/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
+++ b/Apps/UI/WindowsForms/PcmHammer/MainForm.cs
@@ -819,7 +819,11 @@ namespace PcmHacking
         /// null path is what asks it to build one from the package.
         /// </summary>
         private string DefaultDocumentBaseName() =>
-            PackageStore.DefaultBaseName(this.loadedPackage, this.loadedPackagePath);
+            PackageStore.DefaultBaseName(
+                this.loadedPackage,
+                this.loadedPackagePath,
+                // The folder the save dialogs open in, so the sequence number skips names already there.
+                Configuration.Settings.BinDirectory);
 
         /// <summary>
         /// Save dialog that supplies the folder and base name for an export. The exporter appends the PCM


### PR DESCRIPTION
WPF parity, CAN bus selection, and write-plan safety

CI
- Build the WPF front end as an experimental, dev-only artifact,
  self-contained single-file (~59 MB) with kernels embedded.
- Scope PcmLibraryWindowsApi's RuntimeIdentifiers to net48; applied to
  every framework it broke any RID-specific publish with NETSDK1082.

Write plan / boot sector
- VPW now honours ForceWriteAllSectors, matching CAN. P05, P05b and P12
  are the types that cannot rewrite boot and all three are VPW, so the
  setting previously did nothing where it mattered.
- A forced pass never erases an unwritable boot sector: identical boot is
  dropped from the plan and the write continues with all other sectors
  forced; differing boot aborts before anything is erased. Gate and write
  loop share one decision so they cannot disagree.

Bus selection
- Vehicle.PrepareBusFor selects the bus from the resolved PCM type; both
  managers use it after every route that resolves a type. Fixes an E38
  running the whole VPW flow when the type came from the file.

Cancellation
- UnlockEcu takes a required token and a 32s wall-clock budget; it was
  uncancellable and could retry for minutes on a silent bus.
- Removed the token-less GetKernelVersion overload that WriteManager had
  picked up by accident, disabling cancellation for that step.

WPF fixes
- Delay dialog counts down; Skip no longer aborts the write.
- Write and Change VIN dialog buttons work (generator appends "Command",
  so CloseCommand() produced CloseCommandCommand).
- Write type defaults in the view model, so WriteType.None can no longer
  reach a running kernel; WriteManager rejects it up front regardless.
- Show the connected interface, from Vehicle.DeviceDescription.

Shared
- PackageStore.DefaultBaseName gives every UI one save-name rule,
  [PCM]_[OSID]_[Date]; a null path asks it to build one.
- Drop the P05c in-development flag and the experimental slave-write
  prompt.
- generate unique and sensible filenames for save automatically
- add WPF version to the github artifacts. Its now tested enough and generally working for read and write. Still might be gaps, though....

Lols
- I guess this is anuts branch now. Ok, we'll just go with that. If this makes no sense, its a typo in the source branch name.